### PR TITLE
Reduce package size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     branches:
       - "*"
-      - "!main"
 env:
   STORE_PATH: ""
 

--- a/.github/workflows/update-release-pr.yml
+++ b/.github/workflows/update-release-pr.yml
@@ -68,7 +68,7 @@ jobs:
           os: ${{ runner.os }}
 
       - name: Build
-        run: pnpm build
+        run: pnpm build:demo
 
       - name: Setup Pages
         uses: actions/configure-pages@v3

--- a/cli/.npmrc
+++ b/cli/.npmrc
@@ -1,0 +1,1 @@
+auto-install-peers=true

--- a/cli/README.md
+++ b/cli/README.md
@@ -6,17 +6,15 @@ This CLI tool converted Vue 2/3 Class Components, i.e., [vue-class-component](ht
 
 Installing is optional as the mainstream package managers have the ability to [hot load packages](#hot-loading).
 
-```console
+```bash
 pnpm add -g @heatsrc/vuedc
-```
-
-```console
+# or
 npm install -g @heatsrc/vuedc
-```
-
-```console
+# or
 yarn global add @heatsrc/vuedc
 ```
+
+**NOTE:** You will need Node 18+ for VueDc to work. Consider using a node version manager, e.g., [nvm](https://github.com/nvm-sh/nvm), to make switching easy if your project is locked to an older version.
 
 ## Usage
 
@@ -43,12 +41,8 @@ Options:
 
 ```bash
 pnpm dlx vuedc -i MyComponent.vue -o MyOutput.vue
-```
-
-```bash
+# or
 npx vuedc -i MyComponent.vue -o MyOutput.vue
-```
-
-```bash
+# or
 yarn dlx vuedc -i MyComponent.vue -o MyOutput.vue
 ```

--- a/client/README.md
+++ b/client/README.md
@@ -1,13 +1,18 @@
 <h1 align="center">
-  <p aria-hidden align="center"><img src="https://github.com/heatsrc/vue-declassified/blob/main/client/assets/vuedc-logo-200.png" aria-hidden /></p>
-  Vue Declassified (vuedc)
+  <div aria-hidden align="center">
+    <img src="https://github.com/heatsrc/vue-declassified/blob/main/client/assets/vuedc-logo-200.png" aria-hidden />
+  </div>
+  <span>Vue Declassified (vuedc)</span>
 </h1>
 
 - [Vue Class Components -\> Vue 3 script setup](#vue-class-components---vue-3-script-setup)
   - [Opinionated decisions](#opinionated-decisions)
-- [Install](#install)
 - [Usage](#usage)
-  - [vuedc CLI](#vuedc-cli)
+  - [vuedc CLI (recommended)](#vuedc-cli-recommended)
+  - [Programmatically](#programmatically)
+    - [Install](#install)
+      - [Dependencies](#dependencies)
+    - [Code](#code)
 - [Supported Features](#supported-features)
   - [vue-class-component](#vue-class-component)
     - [`@Component` / `@Options` (v8.0.0-rc.1)](#component--options-v800-rc1)
@@ -32,21 +37,55 @@ These decisions are made arbitrarily, mostly for sanity and convenience. You get
 - Will be formatted by prettier with default config
   - exception `printWidth` increased to 100 characters
 
-## Install
+## Usage
+
+### vuedc CLI (recommended)
+
+You can call the CLI tool to convert a file directly from a terminal. For more information see the [vuedc](https://github.com/heatsrc/vue-declassified/blob/main/cli/README.md) readme.
+
+```console
+pnpm add -g @heatsrc/vuedc
+# or
+npm install -g @heatsrc/vuedc
+# or
+yarn add -g @heatsrc/vuedc
+
+vuedc -i myVueComponent.vue -o myVueComponent.converted.vue
+```
+
+or run directly with hot loading
+
+```console
+pnpm dlx vuedc -i myVueComponent.vue -o myVueComponent.converted.vue
+# or
+npx vuedc -i myVueComponent.vue -o myVueComponent.converted.vue
+# or
+yarn dlx vuedc -i myVueComponent.vue -o myVueComponent.converted.vue
+```
+
+### Programmatically
+
+#### Install
+
+##### Dependencies
+
+If you want to use this without the cli tool you'll need to ensure you have the following packages installed
+
+- typescript@^5.2.2
+- vue@^3.3.4
+- prettier@^3.0.3
+
+Additionally vue-declassified requires Node 18+
 
 ```console
 pnpm add @heatsrc/vue-declassified
-```
-
-```console
+# or
 npm install @heatsrc/vue-declassified
-```
-
-```console
+# or
 yarn install @heatsrc/vue-declassified
 ```
 
-## Usage
+#### Code
 
 ```ts
 import { convertSfc } from "@heatsrc/vue-declassified";
@@ -80,14 +119,6 @@ const result = convertScript(input);
 console.log(result);
 // import { ref } from 'vue';
 // const myData = ref<string>('foo');
-```
-
-### vuedc CLI
-
-You can call the CLI tool to convert a file directly from a terminal. For more information see the [vuedc](https://github.com/heatsrc/vue-declassified/blob/main/cli/README.md) readme.
-
-```console
-pnpm dlx vuedc -i myVueComponent.vue -o myVueComponent.converted.vue
 ```
 
 ## Supported Features
@@ -139,7 +170,7 @@ pnpm dlx vuedc -i myVueComponent.vue -o myVueComponent.converted.vue
 </details>
 
 <details>
-<summary>`this.<property>` (11 :white_check_mark: / 3 :heavy_check_mark: / 5 :boom:)</summary>
+<summary><code>this.<property></code> (11 :white_check_mark: / 3 :heavy_check_mark: / 5 :boom:)</summary>
 
 |    `this.`     |     supported?     | notes                                                                    |
 | :------------: | :----------------: | ------------------------------------------------------------------------ |
@@ -257,7 +288,7 @@ These are options provided in the decorator call, e.g., `@Component({ components
 ### vue-property-decorator
 
 <details>
-<summary>`Decorators` (6 :white_check_mark: 1 :heavy_check_mark: / 3 :zzz:)</summary>
+<summary><code>Decorators</code> (6 :white_check_mark: 1 :heavy_check_mark: / 3 :zzz:)</summary>
 
 |     decorator      |     supported?     | notes                                                                                        |
 | :----------------: | :----------------: | -------------------------------------------------------------------------------------------- |
@@ -277,7 +308,7 @@ These are options provided in the decorator call, e.g., `@Component({ components
 ### vuex-class
 
 <details>
-<summary>`Decorators` (4 :white_check_mark:, 1 :heavy_check_mark:)</summary>
+<summary><code>Decorators</code> (4 :white_check_mark:, 1 :heavy_check_mark:)</summary>
 
 |  decorator  |     supported?     | notes |
 | :---------: | :----------------: | ----- |

--- a/client/package.json
+++ b/client/package.json
@@ -40,14 +40,14 @@
   },
   "author": "Jared McAteer <jared.mcateer@heatsrc.com>",
   "license": "ISC",
-  "dependencies": {
+  "peerDependencies": {
     "typescript": "^5.2.2",
-    "vue": "^3.3.4"
+    "vue": "^3.3.4",
+    "prettier": "^3.0.3"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^0.34.5",
     "@vitest/ui": "^0.34.5",
-    "prettier": "^3.0.3",
     "rimraf": "^5.0.5",
     "ts-clone-node": "^3.0.0",
     "vite": "^4.4.9",

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,6 +1,6 @@
-import prettier from "prettier";
-import parserTypescript from "prettier/parser-typescript";
-import parserEsTree from "prettier/plugins/estree.js";
+import * as prettier from "prettier";
+import * as parserTypescript from "prettier/parser-typescript";
+import * as parserEsTree from "prettier/plugins/estree.js";
 import { convertAst } from "./convert.js";
 import { readVueFile, writeVueFile } from "./file.js";
 import { getSingleFileProgram } from "./parser.js";

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -27,11 +27,22 @@ export default defineConfig({
       formats: ["es", "cjs", "umd"],
     },
     rollupOptions: {
-      external: ["vue", "typescript"],
+      external: [
+        "vue",
+        "typescript",
+        "vue/compiler-sfc",
+        "prettier",
+        "prettier/parser-typescript",
+        "prettier/plugins/estree.js",
+      ],
       output: {
         globals: {
           vue: "Vue",
           typescript: "ts",
+          prettier: "prettier",
+          "vue/compiler-sfc": "vueCompilerSfc",
+          "prettier/parser-typescript": "parserTypescript",
+          "prettier/plugins/estree.js": "parserEsTree",
         },
       },
     },

--- a/demo/.npmrc
+++ b/demo/.npmrc
@@ -1,0 +1,1 @@
+auto-install-peers=true

--- a/demo/index-dist.html
+++ b/demo/index-dist.html
@@ -18,7 +18,6 @@
       import { createApp } from 'vue'
       import { Repl } from './dist/vue-repl'
       import Monaco from './dist/monaco-editor'
-      import prettier from 'prettier'
       import './dist/style.css'
       createApp(Repl, {
         editor: Monaco,

--- a/demo/index-dist.html
+++ b/demo/index-dist.html
@@ -18,6 +18,7 @@
       import { createApp } from 'vue'
       import { Repl } from './dist/vue-repl'
       import Monaco from './dist/monaco-editor'
+      import prettier from 'prettier'
       import './dist/style.css'
       createApp(Repl, {
         editor: Monaco,

--- a/demo/package.json
+++ b/demo/package.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build:demo": "vite build",
     "build-types": "vue-tsc -p tsconfig.build.json && api-extractor run -c api-extractor.json && node scripts/cleanup.js",
     "build-preview": "vite build -c vite.preview.config.ts",
     "format": "prettier --write .",
@@ -79,15 +79,15 @@
     "monaco-volar": "^0.4.0",
     "onigasm": "^2.2.5",
     "path-browserify": "^1.0.1",
-    "prettier": "^3.0.0",
     "simple-git-hooks": "^2.9.0",
     "sucrase": "^3.34.0",
-    "typescript": "^5.2.2",
     "vite": "^4.4.7",
-    "vue": "^3.3.4",
     "vue-tsc": "1.8.6"
   },
   "dependencies": {
+    "typescript": "^5.2.2",
+    "vue": "^3.3.4",
+    "prettier": "^3.0.0",
     "@heatsrc/vue-declassified": "workspace:*"
   }
 }

--- a/demo/src/monaco/Monaco.vue
+++ b/demo/src/monaco/Monaco.vue
@@ -1,21 +1,21 @@
 <script lang="ts" setup>
+import * as monaco from 'monaco-editor-core'
+import { loadGrammars, loadTheme } from 'monaco-volar'
 import {
-  onMounted,
+  computed,
+  inject,
+  nextTick,
   onBeforeUnmount,
+  onMounted,
   ref,
   shallowRef,
-  nextTick,
-  inject,
   watch,
-  computed,
   type Ref,
 } from 'vue'
-import * as monaco from 'monaco-editor-core'
+import type { PreviewMode } from '../editor/types'
+import { Store } from '../store'
 import { initMonaco } from './env'
 import { getOrCreateModel } from './utils'
-import { loadGrammars, loadTheme } from 'monaco-volar'
-import { Store } from '../store'
-import type { PreviewMode } from '../editor/types'
 
 const props = withDefaults(
   defineProps<{
@@ -64,6 +64,7 @@ onMounted(async () => {
     minimap: {
       enabled: false,
     },
+    quickSuggestions: false,
     inlineSuggest: {
       enabled: false,
     },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "turbo test",
     "lint": "turbo lint",
     "build": "turbo build",
+    "build:demo": "turbo build:demo",
     "dev": "turbo dev",
     "release": "changeset publish",
     "changeset": "changeset"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
 
   client:
     dependencies:
+      prettier:
+        specifier: ^3.0.3
+        version: 3.0.3
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -70,9 +73,6 @@ importers:
       '@vitest/ui':
         specifier: ^0.34.5
         version: 0.34.6(vitest@0.34.6)
-      prettier:
-        specifier: ^3.0.3
-        version: 3.0.3
       rimraf:
         specifier: ^5.0.5
         version: 5.0.5
@@ -94,6 +94,15 @@ importers:
       '@heatsrc/vue-declassified':
         specifier: workspace:*
         version: link:../client
+      prettier:
+        specifier: ^3.0.0
+        version: 3.0.3
+      typescript:
+        specifier: ^5.2.2
+        version: 5.2.2
+      vue:
+        specifier: ^3.3.4
+        version: 3.3.4
     devDependencies:
       '@babel/types':
         specifier: ^7.22.5
@@ -158,24 +167,15 @@ importers:
       path-browserify:
         specifier: ^1.0.1
         version: 1.0.1
-      prettier:
-        specifier: ^3.0.0
-        version: 3.0.3
       simple-git-hooks:
         specifier: ^2.9.0
         version: 2.9.0
       sucrase:
         specifier: ^3.34.0
         version: 3.34.0
-      typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
       vite:
         specifier: ^4.4.7
         version: 4.4.11(@types/node@20.8.4)
-      vue:
-        specifier: ^3.3.4
-        version: 3.3.4
       vue-tsc:
         specifier: 1.8.6
         version: 1.8.6(typescript@5.2.2)
@@ -3372,7 +3372,7 @@ packages:
     resolution: {integrity: sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==}
     engines: {node: '>=14'}
     hasBin: true
-    dev: true
+    dev: false
 
   /pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
+    "build:demo": { "dependsOn": ["^build"], "outputs": ["dist/**"] },
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]
@@ -8,7 +9,7 @@
     "lint": {
       "dependsOn": ["^build"]
     },
-    "test": {},
+    "test": { "outputs": ["coverage/**"] },
     "dev": {
       "cache": false
     }


### PR DESCRIPTION
vue-declassified's package size is 23MB! Lets move typescript, prettier and vue into peer dependencies and let the projects implementing this library import them.