### PR TITLE
Reset registry after converting script

### DIFF
--- a/.changeset/quick-eels-dream.md
+++ b/.changeset/quick-eels-dream.md
@@ -1,0 +1,5 @@
+---
+"@heatsrc/vue-declassified": patch
+---
+
+Reset registry after converting script

--- a/client/src/__tests__/main.test.ts
+++ b/client/src/__tests__/main.test.ts
@@ -112,7 +112,6 @@ div {
 
       expect(result).toMatchInlineSnapshot(`
         "<script setup lang=\\"ts\\">
-
         /*
         [VUEDC_TODO] Fix naming collisions
          

--- a/client/src/file.ts
+++ b/client/src/file.ts
@@ -1,5 +1,4 @@
 import * as sfcCompiler from "vue/compiler-sfc";
-import { getCollisionsWarning } from "./helpers/collisionDetection.js";
 
 /**
  * Uses vue compiler to parse a vue file
@@ -28,10 +27,8 @@ export async function writeVueFile(vueFile: sfcCompiler.SFCParseResult, scriptCo
   if (!vueFile.descriptor.script) throw new Error("Vue file has no script!");
 
   const lang = vueFile.descriptor.script.lang;
-  let warnings = getCollisionsWarning();
-  warnings = warnings ? `\n\n/*\n${warnings}\n*/\n` : "";
 
-  let fileContent = `<script setup${addLang(lang)}>${warnings}\n${scriptContent}\n</script>`;
+  let fileContent = `<script setup${addLang(lang)}>\n${scriptContent}\n</script>`;
   fileContent += getTemplate(vueFile);
   fileContent += getStyles(vueFile);
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -6,7 +6,7 @@ import { convertAst } from "./convert.js";
 import { readVueFile, writeVueFile } from "./file.js";
 import { getCollisionsWarning } from "./helpers/collisionDetection.js";
 import { getSingleFileProgram } from "./parser.js";
-import { hasCollisions } from "./registry.js";
+import { hasCollisions, resetRegistry } from "./registry.js";
 
 export type VuedcOptions = {
   /** When true Vuedc will not "write" the vue file and instead return the variable collisions */
@@ -71,6 +71,8 @@ export async function convertScript(src: string, opts: Partial<VuedcOptions> = {
   if (opts.stopOnCollisions && hasCollisions()) {
     throw new VuedcError(getCollisionsWarning(false));
   }
+
+  resetRegistry();
 
   return formattedResult;
 }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -62,15 +62,19 @@ export async function convertScript(src: string, opts: Partial<VuedcOptions> = {
   }
   const { ast, program } = getSingleFileProgram(src, tsConfigPath);
   const result = convertAst(ast, program);
-  const formattedResult = await prettier.format(result, {
-    parser: "typescript",
-    printWidth: 100,
-    plugins: [parserTypescript, parserEsTree],
-  });
 
   if (opts.stopOnCollisions && hasCollisions()) {
     throw new VuedcError(getCollisionsWarning(false));
   }
+
+  let warnings = getCollisionsWarning();
+  warnings = warnings ? `\n/*\n${warnings}\n*/\n\n` : "";
+
+  const formattedResult = await prettier.format(warnings + result, {
+    parser: "typescript",
+    printWidth: 100,
+    plugins: [parserTypescript, parserEsTree],
+  });
 
   resetRegistry();
 


### PR DESCRIPTION
The registry needs to be reset for long running scripts such as the one on the vuedc playground otherwise subsequent changes will detect variables from previous conversion as potential collisions.