### PR TITLE
Add "mixins" support

### DIFF
--- a/.changeset/ten-apples-nail.md
+++ b/.changeset/ten-apples-nail.md
@@ -1,0 +1,7 @@
+---
+"@heatsrc/vuedc": minor
+---
+
+Remove tsConfig filepath from project flag
+
+vue-declassified now infers the tsconfig from the sfc file path

--- a/.changeset/ten-suits-type.md
+++ b/.changeset/ten-suits-type.md
@@ -1,0 +1,13 @@
+---
+"@heatsrc/vue-declassified": major
+---
+
+# Support mixins
+
+When provided a `basePath` in the options `vuedc` will attempt to load the TS project so it can look up instance properties of mixins in the class body and them to a theoretical composable in the same file as the mixin.
+
+Note: loading the project file is significantly slower than a single file program, so it's not currently recommended to use it unless mixins are involved.
+
+BREAKING CHANGES
+
+- `VuedcOptions` now takes a `basePath` for the file being converted rather than `tsConfigPath`. The `tsconfig.json` project file will be deduced from the `basePath`.

--- a/cli/README.md
+++ b/cli/README.md
@@ -36,14 +36,14 @@ Usage: vuedc [options]
 Convert Vue Class Components to Vue 3 Composition API
 
 Options:
-  -V, --version                 output the version number
-  --ignore-collisions           Will not stop on collisions
-  -p, --project [tsconfigPath]  Use compiler options from specified tsconfig.json file, if no file path specified with the flag vuedc will attempt to derive it from the input file.
-                                WARNING: this option is significantly slower than not using it, only enable if you need external references (e.g., deriving sources of properties from mixins)!
-  -i, --input <file>            Input Vue file
-  -o, --output <file>           Output file, if not specified input file will be overwritten
-  -y, --yes                     Overwrite output file without asking
-  -h, --help                    display help for command
+  -V, --version        output the version number
+  --ignore-collisions  Will not stop on collisions
+  -p, --project        Use compiler options from tsconfig.json file, vuedc will attempt to derive the `tsconfig.json` from the input file.
+                       WARNING: this option is significantly slower than not using it, only enable if you need external references (e.g., deriving sources of properties from mixins)!
+  -i, --input <file>   Input Vue file
+  -o, --output <file>  Output file, if not specified input file will be overwritten
+  -y, --yes            Overwrite output file without asking
+  -h, --help           display help for command
 ```
 
 ### Hot loading

--- a/cli/src/vuedc.ts
+++ b/cli/src/vuedc.ts
@@ -17,8 +17,8 @@ async function main() {
     .description("Convert Vue Class Components to Vue 3 Composition API")
     .option("--ignore-collisions", "Will not stop on collisions")
     .option(
-      "-p, --project [tsconfigPath]",
-      "Use compiler options from specified tsconfig.json file, if no file path specified with the flag vuedc will attempt to derive it from the input file." +
+      "-p, --project",
+      "Use compiler options from tsconfig.json file, vuedc will attempt to derive the `tsconfig.json` from the input file." +
         "\nWARNING: this option is significantly slower than not using it, only enable if you need external references (e.g., deriving sources of properties from mixins)!",
     )
     .requiredOption("-i, --input <file>", "Input Vue file")
@@ -55,21 +55,17 @@ async function main() {
     return readline.close();
   }
 
-  let tsConfigPath = "";
+  let basePath = "";
   if (options.project === true) {
-    const basePath = options.input.split("/").slice(0, -1).join("/");
-    tsConfigPath = basePath + "/tsconfig.json";
-    console.log(`Will look for tsconfig starting at: ${highlightFile(basePath)}`);
-  } else if (typeof options.project === "string") {
-    tsConfigPath = options.project;
-    console.log(`Using tsconfig file: ${highlightFile(tsConfigPath)}`);
+    basePath = options.input.split("/").slice(0, -1).join("/");
+    console.log(`Will look for tsconfig.json starting at: ${highlightFile(basePath)}`);
   }
 
   console.log(`Converting: ${highlightFile(options.input)}...`);
 
   try {
     const content = await readFile(options.input, { encoding: "utf8" });
-    const opts: VuedcOptions = { stopOnCollisions: !options.collisions, tsConfigPath };
+    const opts: VuedcOptions = { stopOnCollisions: !options.collisions, basePath };
     const result = await convertSfc(content, opts);
 
     await writeFile(output, result, { encoding: "utf8" });

--- a/client/README.md
+++ b/client/README.md
@@ -48,6 +48,16 @@ These decisions are made arbitrarily, mostly for sanity and convenience. You get
 - Will reference macros by arbitrary variables (see below)
 - Will be formatted by prettier with default config
   - exception `printWidth` increased to 100 characters
+- Mixins will be renamed to match composable conventions
+  - Transform
+    - First char of mixin will be capitalized
+    - `use` will be prefixed
+    - `Mixin` will be removed (if detected)
+    - e.g., `FooMixin` -> `useFoo`;
+  - Exported variables are mapped 1:1 with public members of Mixin
+    - e.g., `const { isLoading, bar, fetchData } = useFoo();`
+  - Property/Accessors will have `.value` added to the property access
+    - e.g., `const isReady = computed(() => !isLoading.value)`
 
 ## Usage
 
@@ -148,17 +158,17 @@ console.log(result);
 <details>
 <summary>Basic class transforms (5 :white_check_mark: / 2 :heavy_check_mark:)</summary>
 
-|      feature       |     supported?     | notes                                  |
-| :----------------: | :----------------: | -------------------------------------- |
-|      methods       | :white_check_mark: | Basic method support (no decorators)   |
-|  data properties   | :white_check_mark: | Basic class properties (no decorators) |
-|  getters/setters   | :white_check_mark: | Computed refs                          |
-|       mixins       | :heavy_check_mark: |                                        |
-|       extend       | :heavy_check_mark: |                                        |
-| sort by dependency | :white_check_mark: | Will try to sort dependencies\*        |
-|  `$refs:! {...}`   | :white_check_mark: | converted to regular `Ref`s            |
+|      feature       |     supported?     | notes                                                                                                                                                                                                      |
+| :----------------: | :----------------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|      methods       | :white_check_mark: | Basic method support (no decorators)                                                                                                                                                                       |
+|  data properties   | :white_check_mark: | Basic class properties (no decorators)                                                                                                                                                                     |
+|  getters/setters   | :white_check_mark: | Computed refs                                                                                                                                                                                              |
+|       mixins       | :white_check_mark: | :exclamation:Requires `basePath` option to be set <br /> so the program can reverse lookup the owner of unknown property accesses. <br> Also requires `tsconfig.json` to be somewhere along the `basePath` |
+|       extend       | :heavy_check_mark: |                                                                                                                                                                                                            |
+| sort by dependency | :white_check_mark: | Will try to sort dependencies\*                                                                                                                                                                            |
+|  `$refs:! {...}`   | :white_check_mark: | converted to regular `Ref`s                                                                                                                                                                                |
 
-<sup>\* VueDc does it best to sort dependencies to avoid used before defined issues. It requires processing essentially a directed acyclic graph and it's complicated so please raise issues if found.</sup>
+<sup>\* VueDc does it best to sort dependencies to avoid "used before defined" issues. It requires processing essentially a directed acyclic graph and it's complicated so please raise issues if found.</sup>
 
 </details>
 

--- a/client/package.json
+++ b/client/package.json
@@ -66,6 +66,8 @@
     "ts-clone-node": "^3.0.0",
     "vite": "^4.4.9",
     "vite-plugin-dts": "^3.6.0",
-    "vitest": "^0.34.4"
+    "vitest": "^0.34.4",
+    "vue-class-component": "8.0.0-rc.1",
+    "vue-property-decorator": "10.0.0-rc.3"
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -60,6 +60,7 @@
     "vue": "^3.3.4"
   },
   "devDependencies": {
+    "@types/debug": "^4.1.10",
     "@vitest/coverage-v8": "^0.34.5",
     "@vitest/ui": "^0.34.5",
     "rimraf": "^5.0.5",
@@ -69,5 +70,8 @@
     "vitest": "^0.34.4",
     "vue-class-component": "8.0.0-rc.1",
     "vue-property-decorator": "10.0.0-rc.3"
+  },
+  "dependencies": {
+    "debug": "^4.3.4"
   }
 }

--- a/client/src/__tests__/parser.test.ts
+++ b/client/src/__tests__/parser.test.ts
@@ -21,6 +21,7 @@ describe("test parser", function () {
     let content = "@Component\nexport class Test {}";
     let { ast, program } = getSingleFileProgram(
       content,
+      resolve(__dirname + "/fixtures/"),
       resolve(__dirname + "/fixtures/tsconfig.json"),
     );
     expect(ast.kind).toEqual(ts.SyntaxKind.SourceFile);

--- a/client/src/convert.ts
+++ b/client/src/convert.ts
@@ -17,7 +17,7 @@ export function convertAst(source: ts.SourceFile, program: ts.Program) {
   const outsideStatements = getOutsideStatements(source);
   registerImportNameOverrides(outsideStatements);
 
-  let resultStatements = [...outsideStatements, ...runTransforms(defaultExportNode, program)];
+  let resultStatements = runTransforms(defaultExportNode, outsideStatements, program);
 
   // Group imports at start
   resultStatements = [

--- a/client/src/file.ts
+++ b/client/src/file.ts
@@ -1,4 +1,7 @@
+import Debug from "debug";
 import * as sfcCompiler from "vue/compiler-sfc";
+
+const debug = Debug("vuedc:parser");
 
 /**
  * Uses vue compiler to parse a vue file
@@ -7,6 +10,7 @@ import * as sfcCompiler from "vue/compiler-sfc";
  * @returns the parsed vue file
  */
 export async function readVueFile(content: string) {
+  debug(`Parsing vue file`);
   const vueFile = sfcCompiler.parse(content);
 
   if (vueFile.errors.length > 0)
@@ -24,6 +28,7 @@ export async function readVueFile(content: string) {
  * @param scriptContent Script content to write
  */
 export async function writeVueFile(vueFile: sfcCompiler.SFCParseResult, scriptContent: string) {
+  debug(`Compiling vue file`);
   if (!vueFile.descriptor.script) throw new Error("Vue file has no script!");
 
   const lang = vueFile.descriptor.script.lang;

--- a/client/src/helpers/collisionDetection.ts
+++ b/client/src/helpers/collisionDetection.ts
@@ -1,5 +1,6 @@
 import { instancePropertyKeyMap } from "@/transformer/transforms/utils/instancePropertyAccess.js";
 import { VxTransformResult } from "@/types.js";
+import Debug from "debug";
 import ts from "typescript";
 import {
   addCollision,
@@ -11,6 +12,8 @@ import {
   registerTopLevelVariables,
   registeredVariableTypes,
 } from "../registry.js";
+
+const debug = Debug("vuedc:transformer:helpers:collisionDetection");
 
 export function registerTopLevelVars(statements: ts.Statement[]) {
   const imports = statements.filter(ts.isImportDeclaration);
@@ -56,6 +59,7 @@ function traverseObjBindings(obj: ts.ObjectBindingPattern | ts.ArrayBindingPatte
 }
 
 export function detectNamingCollisions(results: VxTransformResult<ts.Node>[]) {
+  debug("Detecting naming collisions");
   results.forEach((result) => {
     result.outputVariables.forEach((name) => {
       if (isTopLevelVariableRegistered(name)) {
@@ -63,6 +67,7 @@ export function detectNamingCollisions(results: VxTransformResult<ts.Node>[]) {
       }
 
       if (hasClassBodyVariable(name) && !instancePropertyKeyMap.has(`$${name}`)) {
+        debug(`Collision detected for: ${name}`);
         addCollision(name, result.tag, "class body");
       }
 

--- a/client/src/parser.ts
+++ b/client/src/parser.ts
@@ -1,4 +1,7 @@
 import { createProjectSync, ts } from "@ts-morph/bootstrap";
+import Debug from "debug";
+
+const debug = Debug("vuedc:parser");
 
 const compilerOptions: ts.CompilerOptions = {
   allowNonTsExtensions: true,
@@ -15,10 +18,12 @@ const compilerOptions: ts.CompilerOptions = {
  * @returns AST and TS Program
  */
 export function getSingleFileProgram(content: string, basePath = ".", tsConfigFilePath?: string) {
+  debug(`Creating TS Project with basePath: ${basePath}`);
   const project = createProjectSync(
     tsConfigFilePath ? { tsConfigFilePath } : { compilerOptions, useInMemoryFileSystem: true },
   );
   const filePath = `${basePath}/ast.ts`;
+  debug(`Creating source file: ${filePath}`);
   project.createSourceFile(filePath, content);
   const program = project.createProgram();
   const ast = program.getSourceFile(filePath);

--- a/client/src/parser.ts
+++ b/client/src/parser.ts
@@ -1,5 +1,4 @@
 import { createProjectSync, ts } from "@ts-morph/bootstrap";
-import { join } from "node:path";
 
 const compilerOptions: ts.CompilerOptions = {
   allowNonTsExtensions: true,
@@ -15,13 +14,11 @@ const compilerOptions: ts.CompilerOptions = {
  * @param content Vue script content
  * @returns AST and TS Program
  */
-export function getSingleFileProgram(content: string, basePath = "", tsConfigPath?: string) {
+export function getSingleFileProgram(content: string, basePath = ".", tsConfigFilePath?: string) {
   const project = createProjectSync(
-    tsConfigPath
-      ? { tsConfigFilePath: tsConfigPath }
-      : { compilerOptions, useInMemoryFileSystem: true },
+    tsConfigFilePath ? { tsConfigFilePath } : { compilerOptions, useInMemoryFileSystem: true },
   );
-  const filePath = join(basePath, "/ast.ts");
+  const filePath = `${basePath}/ast.ts`;
   project.createSourceFile(filePath, content);
   const program = project.createProgram();
   const ast = program.getSourceFile(filePath);

--- a/client/src/parser.ts
+++ b/client/src/parser.ts
@@ -1,4 +1,5 @@
 import { createProjectSync, ts } from "@ts-morph/bootstrap";
+import { join } from "node:path";
 
 const compilerOptions: ts.CompilerOptions = {
   allowNonTsExtensions: true,
@@ -14,15 +15,16 @@ const compilerOptions: ts.CompilerOptions = {
  * @param content Vue script content
  * @returns AST and TS Program
  */
-export function getSingleFileProgram(content: string, tsConfigPath?: string) {
+export function getSingleFileProgram(content: string, basePath = "", tsConfigPath?: string) {
   const project = createProjectSync(
     tsConfigPath
       ? { tsConfigFilePath: tsConfigPath }
       : { compilerOptions, useInMemoryFileSystem: true },
   );
-  project.createSourceFile("ast.ts", content);
+  const filePath = join(basePath, "/ast.ts");
+  project.createSourceFile(filePath, content);
   const program = project.createProgram();
-  const ast = program.getSourceFile("ast.ts");
+  const ast = program.getSourceFile(filePath);
   if (!ast) throw new Error("Can't convert code to TypeScript AST.");
   return { ast, program };
 }

--- a/client/src/registry.ts
+++ b/client/src/registry.ts
@@ -10,6 +10,7 @@ class Registry {
   ]);
   collisions = new Map<string, { tag: string; sources: Set<string> }>();
   importNameOverrides = new Map<string, string>();
+  warnings = new Set<string>();
 }
 const registry = new Registry();
 
@@ -20,6 +21,7 @@ export function resetRegistry() {
   registry.variableNames.get("classBody")!.clear();
   registry.importNameOverrides.clear();
   registry.collisions.clear();
+  registry.warnings.clear();
 }
 
 export function isDecoratorRegistered(decorator: string) {
@@ -86,4 +88,12 @@ export function hasImportNameOverride(importName: string) {
 
 export function getImportNameOverride(importName: string) {
   return registry.importNameOverrides.get(importName);
+}
+
+export function addGlobalWarning(message: string) {
+  registry.warnings.add(message);
+}
+
+export function getGlobalWarnings() {
+  return [...registry.warnings];
 }

--- a/client/src/registry.ts
+++ b/client/src/registry.ts
@@ -1,3 +1,5 @@
+import Debug from "debug";
+const debug = Debug("vuedc:registry");
 /**
  * Global registry singleton for file level metadata that can be useful
  */
@@ -15,6 +17,7 @@ class Registry {
 const registry = new Registry();
 
 export function resetRegistry() {
+  debug("Resetting registry");
   registry.decorators.clear();
   registry.variableNames.get("imports")!.clear();
   registry.variableNames.get("topLevel")!.clear();
@@ -29,10 +32,12 @@ export function isDecoratorRegistered(decorator: string) {
 }
 
 export function registerDecorator(decorator: string) {
+  debug(`Registering decorator: ${decorator}`);
   registry.decorators.add(decorator);
 }
 
 export function registerTopLevelVariables(ids: string[], isImport = false) {
+  debug(`Registering top level variables: ${ids.join(", ")}`);
   const topLevelIds = registry.variableNames.get(isImport ? "imports" : "topLevel")!;
   ids.forEach(topLevelIds.add, topLevelIds);
 }
@@ -45,10 +50,12 @@ export function isTopLevelVariableRegistered(id: string) {
 }
 
 export function registerClassBodyVariable(id: string) {
+  debug(`Registering class body variable: ${id}`);
   registry.variableNames.get("classBody")!.add(id);
 }
 
 export function registeredVariableTypes(id: string) {
+  debug(`Getting registered variable types: ${id}`);
   const registeredIn = [];
   if (registry.variableNames.get("imports")!.has(id)) registeredIn.push("import declarations");
   if (registry.variableNames.get("topLevel")!.has(id))
@@ -69,6 +76,7 @@ export function hasCollision(varName: string) {
 }
 
 export function addCollision(varName: string, tag: string, source: string) {
+  debug(`Adding collision for: ${varName}`);
   const collision = registry.collisions.get(varName) ?? { tag, sources: new Set() };
   collision.sources.add(source);
   registry.collisions.set(varName, collision);
@@ -79,6 +87,7 @@ export function getCollisions() {
 }
 
 export function setImportNameOverride(importName: string, override: string) {
+  debug(`Setting import name override: ${importName} -> ${override}`);
   registry.importNameOverrides.set(importName, override);
 }
 
@@ -87,10 +96,12 @@ export function hasImportNameOverride(importName: string) {
 }
 
 export function getImportNameOverride(importName: string) {
+  debug(`Getting import name override: ${importName}`);
   return registry.importNameOverrides.get(importName);
 }
 
 export function addGlobalWarning(message: string) {
+  debug(`Adding global warning: ${message}`);
   registry.warnings.add(message);
 }
 

--- a/client/src/registry.ts
+++ b/client/src/registry.ts
@@ -9,6 +9,7 @@ class Registry {
     ["classBody", new Set()],
   ]);
   collisions = new Map<string, { tag: string; sources: Set<string> }>();
+  importNameOverrides = new Map<string, string>();
 }
 const registry = new Registry();
 
@@ -17,6 +18,7 @@ export function resetRegistry() {
   registry.variableNames.get("imports")!.clear();
   registry.variableNames.get("topLevel")!.clear();
   registry.variableNames.get("classBody")!.clear();
+  registry.importNameOverrides.clear();
   registry.collisions.clear();
 }
 
@@ -72,4 +74,16 @@ export function addCollision(varName: string, tag: string, source: string) {
 
 export function getCollisions() {
   return [...registry.collisions.entries()];
+}
+
+export function setImportNameOverride(importName: string, override: string) {
+  registry.importNameOverrides.set(importName, override);
+}
+
+export function hasImportNameOverride(importName: string) {
+  return registry.importNameOverrides.has(importName);
+}
+
+export function getImportNameOverride(importName: string) {
+  return registry.importNameOverrides.get(importName);
 }

--- a/client/src/transformer.ts
+++ b/client/src/transformer.ts
@@ -6,17 +6,33 @@ import { getBody, getComposables, getImports, getMacros } from "./transformer/re
 import { processClassDecorator, processClassMember } from "./transformer/statementsProcessor.js";
 import { VxTransformResult } from "./types.js";
 
-export function runTransforms(node: ts.ClassDeclaration, program: ts.Program) {
+export function runTransforms(
+  node: ts.ClassDeclaration,
+  outsideStatements: ts.Statement[],
+  program: ts.Program,
+) {
   const results = getAstResults(node, program);
 
-  const imports = getImports(results);
+  const outsideImports = outsideStatements.filter((s) =>
+    ts.isImportDeclaration(s),
+  ) as ts.ImportDeclaration[];
+  const outsideStatementsWithoutImports = outsideStatements.filter(
+    (s) => !ts.isImportDeclaration(s),
+  );
+  const imports = getImports(results, outsideImports);
   const macros = getMacros(results);
   const composables = getComposables(results);
   const body = getBody(results);
 
   prependSyntheticComments(imports[0], node);
 
-  return [...imports, ...macros, ...composables, ...body] as ts.Statement[];
+  return [
+    ...imports,
+    ...outsideStatementsWithoutImports,
+    ...macros,
+    ...composables,
+    ...body,
+  ] as ts.Statement[];
 }
 
 function getAstResults(node: ts.ClassDeclaration, program: ts.Program) {

--- a/client/src/transformer.ts
+++ b/client/src/transformer.ts
@@ -1,3 +1,4 @@
+import Debug from "debug";
 import ts from "typescript";
 import { detectNamingCollisions } from "./helpers/collisionDetection.js";
 import { prependSyntheticComments } from "./helpers/comments.js";
@@ -6,11 +7,14 @@ import { getBody, getComposables, getImports, getMacros } from "./transformer/re
 import { processClassDecorator, processClassMember } from "./transformer/statementsProcessor.js";
 import { VxTransformResult } from "./types.js";
 
+const debug = Debug("vuedc:transformer");
+
 export function runTransforms(
   node: ts.ClassDeclaration,
   outsideStatements: ts.Statement[],
   program: ts.Program,
 ) {
+  debug("Running transforms");
   const results = getAstResults(node, program);
 
   const outsideImports = outsideStatements.filter((s) =>
@@ -38,6 +42,7 @@ export function runTransforms(
 function getAstResults(node: ts.ClassDeclaration, program: ts.Program) {
   let results: VxTransformResult<ts.Node>[] = [];
 
+  debug("Processing class component");
   node.forEachChild((child) => {
     if (ts.isDecorator(child)) {
       const res = processClassDecorator(child, program);
@@ -48,6 +53,7 @@ function getAstResults(node: ts.ClassDeclaration, program: ts.Program) {
     }
   });
 
+  debug("Running post processors");
   for (const postProcessor of classTransforms.after) {
     results = postProcessor(results, program);
   }

--- a/client/src/transformer/config.ts
+++ b/client/src/transformer/config.ts
@@ -15,14 +15,15 @@ import { transformMethod } from "./transforms/vue-class-component/Method.js";
 import { transformTemplateRef } from "./transforms/vue-class-component/TemplateRef.js";
 import { transformOptionsEmits } from "./transforms/vue-class-component/decorator-options/Emits.js";
 import { transformOptionsExpose } from "./transforms/vue-class-component/decorator-options/Expose.js";
-import { transformDecoratorInject } from "./transforms/vue-property-decorator/Inject.js";
 import { transformOptionsProps } from "./transforms/vue-class-component/decorator-options/Props.js";
-import { transformDecoratorProvide } from "./transforms/vue-property-decorator/Provide.js";
 import { transformOptionsWatch } from "./transforms/vue-class-component/decorator-options/Watches.js";
 import { transformEmitDecorator } from "./transforms/vue-property-decorator/Emit.js";
+import { transformDecoratorInject } from "./transforms/vue-property-decorator/Inject.js";
 import { transformDecoratorProp } from "./transforms/vue-property-decorator/Prop.js";
+import { transformDecoratorProvide } from "./transforms/vue-property-decorator/Provide.js";
 import { transformDecoratorRef } from "./transforms/vue-property-decorator/Ref.js";
 import { transformWatchDecorator } from "./transforms/vue-property-decorator/Watch.js";
+import { transformMixins } from "./transforms/vue-property-decorator/mixins.js";
 import { transformVuexAction } from "./transforms/vuex-class/Action.js";
 import { transformVuexGetter } from "./transforms/vuex-class/Getter.js";
 import { transformVuexMutation } from "./transforms/vuex-class/Mutation.js";
@@ -45,7 +46,7 @@ export const classTransforms: VxClassTransforms = {
   /** Class name */
   [ts.SyntaxKind.Identifier]: [],
   /** extends Vue | Mixins */
-  [ts.SyntaxKind.HeritageClause]: [],
+  [ts.SyntaxKind.HeritageClause]: [transformMixins],
   /** Data properties, @Model, @Prop, @Watch, @Provide, @Inject, @Ref, @State, @Getter, @Action, @Mutation */
   [ts.SyntaxKind.PropertyDeclaration]: [
     // Vue Class Component

--- a/client/src/transformer/resultsProcessor.ts
+++ b/client/src/transformer/resultsProcessor.ts
@@ -7,8 +7,21 @@ import {
   isMacroType,
 } from "../types.js";
 
-export function getImports(results: VxTransformResult<ts.Node>[]) {
+export function getImports(
+  results: VxTransformResult<ts.Node>[],
+  outsideImports: ts.ImportDeclaration[] = [],
+) {
   const importMap = new Map<string, VxImportClause>();
+
+  outsideImports.forEach((imp) => {
+    const clause: VxImportClause = { named: new Set() };
+    const name = imp.importClause?.name?.text;
+    if (name) clause.default = name;
+    imp.importClause?.namedBindings?.forEachChild((el) => {
+      if (ts.isImportSpecifier(el)) clause.named.add(el.name.text);
+    });
+    importMap.set((imp.moduleSpecifier as ts.StringLiteral).text, clause);
+  });
 
   results.forEach(({ imports }) => {
     imports.forEach((i) => {

--- a/client/src/transformer/resultsProcessor.ts
+++ b/client/src/transformer/resultsProcessor.ts
@@ -1,3 +1,4 @@
+import Debug from "debug";
 import ts from "typescript";
 import {
   VxImportClause,
@@ -7,10 +8,13 @@ import {
   isMacroType,
 } from "../types.js";
 
+const debug = Debug("vuedc:transformer:resultsProcessor");
+
 export function getImports(
   results: VxTransformResult<ts.Node>[],
   outsideImports: ts.ImportDeclaration[] = [],
 ) {
+  debug("Collating imports");
   const importMap = new Map<string, VxImportClause>();
 
   outsideImports.forEach((imp) => {
@@ -43,6 +47,7 @@ export function getImports(
     const namedImports =
       importElements.length > 0 ? ts.factory.createNamedImports(importElements) : undefined;
 
+    debug(`Creating import declaration for: ${key}`);
     return ts.factory.createImportDeclaration(
       undefined,
       ts.factory.createImportClause(false, name, namedImports),
@@ -52,13 +57,16 @@ export function getImports(
 }
 
 export function getBody(results: VxTransformResult<ts.Node>[]) {
+  debug("Collating body");
   return results.filter(isCompositionType).flatMap((el) => el.nodes);
 }
 
 export function getMacros(results: VxTransformResult<ts.Node>[]) {
+  debug("Collating Macros");
   return results.filter(isMacroType).flatMap((el) => el.nodes);
 }
 
 export function getComposables(results: VxTransformResult<ts.Node>[]) {
+  debug("Collating Composables");
   return results.filter(isComposableType).flatMap((el) => el.nodes);
 }

--- a/client/src/transformer/statementsProcessor.ts
+++ b/client/src/transformer/statementsProcessor.ts
@@ -1,3 +1,4 @@
+import Debug from "debug";
 import ts from "typescript";
 import { addTodoComment } from "../helpers/comments.js";
 import {
@@ -9,6 +10,8 @@ import {
   VxTransformResult,
 } from "../types.js";
 import { classTransforms } from "./config.js";
+
+const debug = Debug("vuedc:transformer:statementsProcessor");
 
 const {
   [ts.SyntaxKind.Decorator]: decoratorTransforms,
@@ -51,6 +54,7 @@ export function processClassDecorator(
 
     if (isTransformable(property.kind)) {
       const optionTransforms = transforms[property.kind];
+      debug(`Transforming ${ts.SyntaxKind[property.kind]}}`);
       const opts = processNode(property, program, optionTransforms);
 
       if (opts) results.push(...opts);
@@ -63,6 +67,7 @@ export function processClassDecorator(
 }
 
 function processUnknownOption(node: ts.Node) {
+  debug(`Could not convert unknown decorator option: ${node.getText()}`);
   return {
     imports: [],
     kind: VxResultKind.OPTIONS,

--- a/client/src/transformer/statementsProcessor.ts
+++ b/client/src/transformer/statementsProcessor.ts
@@ -67,7 +67,7 @@ export function processClassDecorator(
 }
 
 function processUnknownOption(node: ts.Node) {
-  debug(`Could not convert unknown decorator option: ${node.getText()}`);
+  debug(`Could not convert unknown decorator option: ${ts.SyntaxKind[node.kind]}}`);
   return {
     imports: [],
     kind: VxResultKind.OPTIONS,

--- a/client/src/transformer/transforms/processPropertyAccessAndSort.ts
+++ b/client/src/transformer/transforms/processPropertyAccessAndSort.ts
@@ -10,8 +10,8 @@ type TransformerResult = {
   readonly astResult: Exclude<VxTransformResult<ts.Node>, VxResultToImport>;
   readonly dependsOn: string[];
 };
-export const processPropertyAccessAndSort: VxPostProcessor = (astResults) => {
-  const variableHandlers = getVariableHandlers(astResults);
+export const processPropertyAccessAndSort: VxPostProcessor = (astResults, program) => {
+  const variableHandlers = getVariableHandlers(astResults, program);
 
   const transformerResults = astResults
     .map((astResult) => {
@@ -33,7 +33,7 @@ export const processPropertyAccessAndSort: VxPostProcessor = (astResults) => {
 };
 
 type VariableHandlers = ReturnType<typeof getVariableHandlers>;
-function getVariableHandlers(astResults: VxTransformResult<ts.Node>[]) {
+function getVariableHandlers(astResults: VxTransformResult<ts.Node>[], program: ts.Program) {
   const getReferences = (ref: VxReferenceKind) => {
     return astResults
       .filter((node) => node.reference === ref)
@@ -57,6 +57,9 @@ function getVariableHandlers(astResults: VxTransformResult<ts.Node>[]) {
     const instanceProperty = transformInstanceProperties(name, definableVariable, definableMethods);
     if (instanceProperty) return instanceProperty;
 
+    // const customComposableProperty = transformCustomComposable(name, node, program);
+    // if (customComposableProperty) return customComposableProperty;
+
     // cloneNode cleanly copies the node and removes any references to the parent
     // without this comments don't properly get copied over
     const clonedNode = cloneNode(node);
@@ -77,6 +80,33 @@ function transformInstanceProperties(name: string, variables: string[], methods:
 
   return false;
 }
+
+// function transformCustomComposable(name: string, node: ts.Node, program: ts.Program) {
+//   const checker = program.getTypeChecker();
+//   const symbol = checker.getSymbolAtLocation(node);
+//   if (!symbol) return false;
+//   if (!symbol.valueDeclaration) return false;
+//   const parent = symbol.valueDeclaration.parent;
+//   if (!parent || !ts.isClassDeclaration(parent)) return false;
+//   const parentName = parent.name;
+//   if (!parentName) return false;
+
+//   const rest = parentName.text.slice(1);
+//   let varName = "$" + parentName.text.charAt(0).toLowerCase() + rest;
+//   varName = varName.replace("Mixin", "");
+
+//   let propertyAccess = createPropertyAccess(varName, name);
+
+//   if (symbol.flags & ts.SymbolFlags.PropertyOrAccessor) {
+//     propertyAccess = createPropertyAccess(propertyAccess, "value");
+//   }
+
+//   addTodoComment(
+//     propertyAccess,
+//     "Check this is correct, assumed property access based on class property/accessor vs method. ",
+//   );
+//   return [propertyAccess] as const;
+// }
 
 function getTransformer(variableHandlers: VariableHandlers, dependents: Set<string>) {
   return ((ctx) => {

--- a/client/src/transformer/transforms/processPropertyAccessAndSort.ts
+++ b/client/src/transformer/transforms/processPropertyAccessAndSort.ts
@@ -57,9 +57,6 @@ function getVariableHandlers(astResults: VxTransformResult<ts.Node>[], program: 
     const instanceProperty = transformInstanceProperties(name, definableVariable, definableMethods);
     if (instanceProperty) return instanceProperty;
 
-    // const customComposableProperty = transformCustomComposable(name, node, program);
-    // if (customComposableProperty) return customComposableProperty;
-
     // cloneNode cleanly copies the node and removes any references to the parent
     // without this comments don't properly get copied over
     const clonedNode = cloneNode(node);
@@ -80,33 +77,6 @@ function transformInstanceProperties(name: string, variables: string[], methods:
 
   return false;
 }
-
-// function transformCustomComposable(name: string, node: ts.Node, program: ts.Program) {
-//   const checker = program.getTypeChecker();
-//   const symbol = checker.getSymbolAtLocation(node);
-//   if (!symbol) return false;
-//   if (!symbol.valueDeclaration) return false;
-//   const parent = symbol.valueDeclaration.parent;
-//   if (!parent || !ts.isClassDeclaration(parent)) return false;
-//   const parentName = parent.name;
-//   if (!parentName) return false;
-
-//   const rest = parentName.text.slice(1);
-//   let varName = "$" + parentName.text.charAt(0).toLowerCase() + rest;
-//   varName = varName.replace("Mixin", "");
-
-//   let propertyAccess = createPropertyAccess(varName, name);
-
-//   if (symbol.flags & ts.SymbolFlags.PropertyOrAccessor) {
-//     propertyAccess = createPropertyAccess(propertyAccess, "value");
-//   }
-
-//   addTodoComment(
-//     propertyAccess,
-//     "Check this is correct, assumed property access based on class property/accessor vs method. ",
-//   );
-//   return [propertyAccess] as const;
-// }
 
 function getTransformer(variableHandlers: VariableHandlers, dependents: Set<string>) {
   return ((ctx) => {

--- a/client/src/transformer/transforms/vue-property-decorator/__tests__/Prop.test.ts
+++ b/client/src/transformer/transforms/vue-property-decorator/__tests__/Prop.test.ts
@@ -76,7 +76,7 @@ describe("Prop decorator", () => {
     const result = convertAst(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
-      "import Bar from './Bar';
+      "import Bar from \\"./Bar\\";
       const props = withDefaults(defineProps<{
           \\"foo\\"?: string;
           \\"bar\\": Bar;

--- a/client/src/transformer/transforms/vue-property-decorator/__tests__/fixtures/MyComponent.vue
+++ b/client/src/transformer/transforms/vue-property-decorator/__tests__/fixtures/MyComponent.vue
@@ -1,0 +1,25 @@
+<script lang="ts">
+import { mixins as Mixins, Options, Watch } from "vue-property-decorator";
+import MyOther from './MyOther';
+import MySpecialMixin from "./MySpecialMixin";
+
+@Options({})
+export default class MyComponent extends Mixins(MySpecialMixin, MyOther) {
+  get myFoo() {
+    return this.foo;
+  }
+
+  @Watch('bar')
+  onBarChanged(newVal: number, oldVal: number) {
+    console.log(`bar changed ${this.bar} vs ${oldVal}`);
+    this.fetchData();
+  }
+
+  mounted() {
+    this.foo = this.baz === 1 ? 'foo' : 'bar';
+  }
+</script>
+
+<template>
+  <div>{{ myFoo }}</div>
+</template>

--- a/client/src/transformer/transforms/vue-property-decorator/__tests__/fixtures/MyOther.ts
+++ b/client/src/transformer/transforms/vue-property-decorator/__tests__/fixtures/MyOther.ts
@@ -1,5 +1,6 @@
 import { Options, Vue } from "vue-class-component";
 
+// @ts-ignore
 @Options({})
 export default class MyOther extends Vue {
   bar: number = 0;

--- a/client/src/transformer/transforms/vue-property-decorator/__tests__/fixtures/MyOther.ts
+++ b/client/src/transformer/transforms/vue-property-decorator/__tests__/fixtures/MyOther.ts
@@ -1,0 +1,10 @@
+import { Options, Vue } from "vue-class-component";
+
+@Options({})
+export default class MyOther extends Vue {
+  bar: number = 0;
+
+  get baz() {
+    return this.bar;
+  }
+}

--- a/client/src/transformer/transforms/vue-property-decorator/__tests__/fixtures/MySpecialMixin.ts
+++ b/client/src/transformer/transforms/vue-property-decorator/__tests__/fixtures/MySpecialMixin.ts
@@ -1,6 +1,7 @@
 import { Options, Vue } from "vue-class-component";
 
 export type MySpecialType = "foo" | "bar";
+// @ts-ignore
 @Options({})
 export default class MySpecialMixin extends Vue {
   foo: MySpecialType = "bar";

--- a/client/src/transformer/transforms/vue-property-decorator/__tests__/fixtures/MySpecialMixin.ts
+++ b/client/src/transformer/transforms/vue-property-decorator/__tests__/fixtures/MySpecialMixin.ts
@@ -1,0 +1,12 @@
+import { Options, Vue } from "vue-class-component";
+
+export type MySpecialType = "foo" | "bar";
+@Options({})
+export default class MySpecialMixin extends Vue {
+  foo: MySpecialType = "bar";
+
+  async fetchData() {
+    const resp = await fetch("https://example.com/foo");
+    this.foo = (await resp.text()) as MySpecialType;
+  }
+}

--- a/client/src/transformer/transforms/vue-property-decorator/__tests__/fixtures/tsconfig.json
+++ b/client/src/transformer/transforms/vue-property-decorator/__tests__/fixtures/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2016",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "experimentalDecorators": true
+  },
+  "include": ["./MyMixin.ts", "./MyComponent.vue"]
+}

--- a/client/src/transformer/transforms/vue-property-decorator/__tests__/mixins.test.ts
+++ b/client/src/transformer/transforms/vue-property-decorator/__tests__/mixins.test.ts
@@ -1,0 +1,41 @@
+import { convertAst } from "@/convert";
+import { readVueFile } from "@/file";
+import { getSingleFileProgram } from "@/parser";
+import { setImportNameOverride } from "@/registry";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("mixins test", () => {
+  it("should transform mixins ", async () => {
+    const file = await readFile(resolve(__dirname, "./fixtures/MyComponent.vue"), "utf-8");
+    const { script } = await readVueFile(file);
+    setImportNameOverride("mixins", "Mixins");
+    const { ast, program } = getSingleFileProgram(
+      script.content,
+      resolve(__dirname, "./fixtures"),
+      resolve(__dirname, "./fixtures/tsconfig.json"),
+    );
+    const result = convertAst(ast, program);
+
+    expect(result).toMatchInlineSnapshot(`
+      "import MyOther, { useMyOther } from \\"./MyOther\\";
+      import MySpecialMixin, { useMySpecial } from \\"./MySpecialMixin\\";
+      import { computed, onMounted } from \\"vue\\";
+      /* [VUEDC_TODO]: Check this is correct. */ const { foo, fetchData } = useMySpecial();
+      /* [VUEDC_TODO]: Check this is correct. */ const { bar, baz } = useMyOther();
+      const myFoo = computed(() => {
+          return foo.value;
+      });
+      const onBarChanged = (newVal: number, oldVal: number) => {
+          console.log(\`bar changed \${bar.value} vs \${oldVal}\`);
+          fetchData();
+      };
+      onMounted(() => {
+          foo.value = baz === 1 ? 'foo' : 'bar';
+      });
+      watch(bar, onBarChanged);
+      "
+    `);
+  });
+});

--- a/client/src/transformer/transforms/vue-property-decorator/mixins.ts
+++ b/client/src/transformer/transforms/vue-property-decorator/mixins.ts
@@ -1,0 +1,29 @@
+import { getImportNameOverride } from "@/registry";
+import { VxTransform } from "@/types";
+import ts from "typescript";
+
+const CLAUSE = "mixins";
+
+export const transformMixins: VxTransform<ts.HeritageClause> = (clause) => {
+  if (!ts.isHeritageClause(clause)) return { shouldContinue: true };
+  if (!isExtendsClause(clause)) return { shouldContinue: true };
+  if (!clause.types) return { shouldContinue: true };
+
+  const typeExpr = clause.types[0].expression;
+  if (!ts.isCallExpression(typeExpr)) return { shouldContinue: true };
+
+  const typeIdent = typeExpr.expression;
+  if (!ts.isIdentifier(typeIdent)) return { shouldContinue: true };
+
+  let clauseName = getImportNameOverride(CLAUSE) ?? CLAUSE;
+  if (typeIdent.text !== clauseName) return { shouldContinue: true };
+
+  const args = typeExpr.arguments;
+  if (!args || args.length <= 0) return { shouldContinue: true };
+
+  const
+};
+
+function isExtendsClause(clause: ts.HeritageClause) {
+  return clause.token === ts.SyntaxKind.ExtendsKeyword;
+}

--- a/client/src/transformer/transforms/vue-property-decorator/mixins.ts
+++ b/client/src/transformer/transforms/vue-property-decorator/mixins.ts
@@ -1,10 +1,19 @@
-import { getImportNameOverride } from "@/registry";
-import { VxTransform } from "@/types";
+import { addTodoComment } from "@/helpers/comments";
+import {
+  createCallExpression,
+  createConstStatement,
+  createPropertyAccess,
+} from "@/helpers/tsHelpers";
+import { namedImports } from "@/helpers/utils";
+import { addGlobalWarning, getImportNameOverride } from "@/registry";
+import { VxReferenceKind, VxResultKind, VxResultToComposable, VxTransform } from "@/types";
 import ts from "typescript";
+import { instancePropertyKeyMap } from "../utils/instancePropertyAccess";
 
 const CLAUSE = "mixins";
+const u = undefined;
 
-export const transformMixins: VxTransform<ts.HeritageClause> = (clause) => {
+export const transformMixins: VxTransform<ts.HeritageClause> = (clause, program) => {
   if (!ts.isHeritageClause(clause)) return { shouldContinue: true };
   if (!isExtendsClause(clause)) return { shouldContinue: true };
   if (!clause.types) return { shouldContinue: true };
@@ -21,7 +30,68 @@ export const transformMixins: VxTransform<ts.HeritageClause> = (clause) => {
   const args = typeExpr.arguments;
   if (!args || args.length <= 0) return { shouldContinue: true };
 
-  const
+  const checker = program.getTypeChecker();
+  const mixins = args.reduce((acc, arg) => {
+    if (!ts.isIdentifier(arg)) return acc;
+
+    const rest = arg.text.slice(1);
+    let name = "use" + arg.text.charAt(0).toUpperCase() + rest;
+    name = name.replace("Mixin", "");
+
+    const type = checker.getSymbolAtLocation(arg);
+    const decl = type?.declarations?.[0];
+    if (!decl || !ts.isImportClause(decl)) return acc;
+
+    let importFileName = (decl.parent.moduleSpecifier as ts.StringLiteral).text;
+    addGlobalWarning(
+      `Mixin "${arg.text}" was assumed to have composable "${name}" in the same file and public members mapped 1:1 with exported variables/functions.`,
+    );
+
+    const mixinClass = checker.getTypeOfSymbolAtLocation(type, arg).symbol.valueDeclaration;
+    if (!mixinClass || !ts.isClassDeclaration(mixinClass)) return acc;
+    let referenceVars: string[] = [];
+    const bindingElements = mixinClass.members.reduce((acc, member) => {
+      if (
+        !ts.isPropertyDeclaration(member) &&
+        !ts.isMethodDeclaration(member) &&
+        !ts.isAccessor(member)
+      ) {
+        return acc;
+      }
+
+      if (member.modifiers?.some((m) => m.kind === ts.SyntaxKind.PrivateKeyword)) return acc;
+
+      const memberName = member.name.getText();
+      const memberVal = ts.isPropertyDeclaration(member)
+        ? createPropertyAccess(memberName, "value")
+        : memberName;
+      instancePropertyKeyMap.set(memberName, memberVal);
+      referenceVars.push(memberName);
+
+      const bindingElement = ts.factory.createBindingElement(u, u, memberName);
+      acc.push(bindingElement);
+
+      return acc;
+    }, [] as ts.BindingElement[]);
+
+    const bindingPattern = ts.factory.createObjectBindingPattern(bindingElements);
+    const callExpr = createCallExpression(name);
+    const constStatement = createConstStatement(bindingPattern, callExpr);
+    addTodoComment(constStatement, "Check this is correct. ");
+
+    acc.push({
+      kind: VxResultKind.COMPOSABLE,
+      reference: VxReferenceKind.DEFINABLE_VARIABLE,
+      tag: `Composable-fromMixin-${name}`,
+      outputVariables: [name, ...referenceVars],
+      imports: namedImports([name], importFileName),
+      nodes: [constStatement],
+    });
+
+    return acc;
+  }, [] as VxResultToComposable[]);
+
+  return { shouldContinue: false, result: mixins };
 };
 
 function isExtendsClause(clause: ts.HeritageClause) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@ts-morph/bootstrap':
         specifier: ^0.21.0
         version: 0.21.0
+      debug:
+        specifier: ^4.3.4
+        version: 4.3.4
       prettier:
         specifier: ^3.0.3
         version: 3.0.3
@@ -70,6 +73,9 @@ importers:
         specifier: ^3.3.4
         version: 3.3.4
     devDependencies:
+      '@types/debug':
+        specifier: ^4.1.10
+        version: 4.1.10
       '@vitest/coverage-v8':
         specifier: ^0.34.5
         version: 0.34.6(vitest@0.34.6)
@@ -974,6 +980,12 @@ packages:
       '@types/tern': 0.23.5
     dev: true
 
+  /@types/debug@4.1.10:
+    resolution: {integrity: sha512-tOSCru6s732pofZ+sMv9o4o3Zc+Sa8l3bxd/tweTQudFn06vAzb13ZX46Zi6m6EJ+RUbRTHvgQJ1gBtSgkaUYA==}
+    dependencies:
+      '@types/ms': 0.7.33
+    dev: true
+
   /@types/estree@1.0.2:
     resolution: {integrity: sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA==}
     dev: true
@@ -994,6 +1006,10 @@ packages:
 
   /@types/minimist@1.2.4:
     resolution: {integrity: sha512-Kfe/D3hxHTusnPNRbycJE1N77WHDsdS4AjUYIzlDzhDrS47NrwuL3YW4VITxwR7KCVpzwgy4Rbj829KSSQmwXQ==}
+    dev: true
+
+  /@types/ms@0.7.33:
+    resolution: {integrity: sha512-AuHIyzR5Hea7ij0P9q7vx7xu4z0C28ucwjAZC0ja7JhINyCnOw8/DnvAPQQ9TfOlCtZAmCERKQX9+o1mgQhuOQ==}
     dev: true
 
   /@types/node@12.20.55:
@@ -1832,7 +1848,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-    dev: true
 
   /decamelize-keys@1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
@@ -3099,7 +3114,6 @@ packages:
 
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
-    dev: true
 
   /muggle-string@0.3.1:
     resolution: {integrity: sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,12 @@ importers:
       vitest:
         specifier: ^0.34.4
         version: 0.34.6(@vitest/ui@0.34.6)
+      vue-class-component:
+        specifier: 8.0.0-rc.1
+        version: 8.0.0-rc.1(vue@3.3.4)
+      vue-property-decorator:
+        specifier: 10.0.0-rc.3
+        version: 10.0.0-rc.3(vue-class-component@8.0.0-rc.1)(vue@3.3.4)
 
   demo:
     dependencies:
@@ -4571,6 +4577,24 @@ packages:
 
   /vscode-uri@3.0.8:
     resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
+    dev: true
+
+  /vue-class-component@8.0.0-rc.1(vue@3.3.4):
+    resolution: {integrity: sha512-w1nMzsT/UdbDAXKqhwTmSoyuJzUXKrxLE77PCFVuC6syr8acdFDAq116xgvZh9UCuV0h+rlCtxXolr3Hi3HyPQ==}
+    peerDependencies:
+      vue: ^3.0.0
+    dependencies:
+      vue: 3.3.4
+    dev: true
+
+  /vue-property-decorator@10.0.0-rc.3(vue-class-component@8.0.0-rc.1)(vue@3.3.4):
+    resolution: {integrity: sha512-EGqjf8Lq+kTausZzfLB1ynWOcyay8ZLAc5p2VlKGEX2q+BjYw84oZxr6IcdwuxGIdNmriZqPUX6AlAluBdnbEg==}
+    peerDependencies:
+      vue: '*'
+      vue-class-component: '*'
+    dependencies:
+      vue: 3.3.4
+      vue-class-component: 8.0.0-rc.1(vue@3.3.4)
     dev: true
 
   /vue-template-compiler@2.7.14:


### PR DESCRIPTION
When mixins are detected vuedc will now map public members on those classes so they are referenced properly.

A mixin will be converted to a composable and all members will be converted 1:1 to exported variables/functions

e.g.,

```ts
@Options({})
class FooMixin extends Vue {
  myData: string = 'foo';
}
```

will become the following in the component that mixes it in:

```ts
const { myData } = useFoo();
```

This is a fairly large change, as it requires loading the ts project in order to be able to follow symbols to other files in order to find out where property accesses are coming from. 
