### PR TITLE
Add support for vuex-class decorator namespacing

### DIFF
--- a/.changeset/pink-singers-camp.md
+++ b/.changeset/pink-singers-camp.md
@@ -1,0 +1,5 @@
+---
+"@heatsrc/vue-declassified": minor
+---
+
+Add support for vuex-class namespaing of Getter and State decorators

--- a/.changeset/pink-singers-camp.md
+++ b/.changeset/pink-singers-camp.md
@@ -2,4 +2,4 @@
 "@heatsrc/vue-declassified": minor
 ---
 
-Add support for vuex-class namespaing of Getter and State decorators
+Add support for vuex-class namespacing of Getter and State decorators

--- a/.changeset/plenty-terms-glow.md
+++ b/.changeset/plenty-terms-glow.md
@@ -1,0 +1,5 @@
+---
+"@heatsrc/vue-declassified": minor
+---
+
+Add support for vuex-class namespacing of Action and Mutation decorators

--- a/client/README.md
+++ b/client/README.md
@@ -352,7 +352,7 @@ These are options provided in the decorator call, e.g., `@Component({ components
 ### vuex-class
 
 <details>
-<summary><code>Decorators</code> (4 :white_check_mark:, 1 :heavy_check_mark:)</summary>
+<summary><code>Decorators</code> (5/5 :rocket:)</summary>
 
 |  decorator  |     supported?     | notes |
 | :---------: | :----------------: | ----- |
@@ -360,7 +360,7 @@ These are options provided in the decorator call, e.g., `@Component({ components
 |  `@Getter`  | :white_check_mark: |       |
 | `@Mutation` | :white_check_mark: |       |
 |  `@State`   | :white_check_mark: |       |
-|  namespace  | :heavy_check_mark: |       |
+|  namespace  | :white_check_mark: |       |
 
 </details>
 

--- a/client/src/__tests__/convert.test.ts
+++ b/client/src/__tests__/convert.test.ts
@@ -279,12 +279,12 @@ describe("convert", () => {
       }>(\\"optional\\", () => ({ foo: \\"bar\\" }));
       // Vuex State
       const title = computed<string>(() => store.state.title);
-      const vehicle = computed(() => store.state['car']);
+      const vehicle = computed(() => store.state.car);
       const userProfile = computed<Profile>(() => store.state[userProfile]);
       const isAdmin = computed<boolean>(() => store.state.user.isAdmin);
       // Vuex Getters
       const direction = computed<string>(() => store.getters.direction);
-      const velocity = computed<number>(() => store.getters['speed']);
+      const velocity = computed<number>(() => store.getters.speed);
       const adminProfile = computed<(id: number) => Profile>(() => store.getters[profile]);
       // Vuex Actions
       const fetchUser = async (id: number): Promise<User> => store.dispatch(\\"fetchUser\\", id);

--- a/client/src/convert.ts
+++ b/client/src/convert.ts
@@ -2,7 +2,12 @@ import Debug from "debug";
 import ts from "typescript";
 import { registerTopLevelVars } from "./helpers/collisionDetection.js";
 import { getDecoratorNames, getPackageName } from "./helpers/tsHelpers.js";
-import { setImportNameOverride } from "./registry.js";
+import {
+  getImportNameOverride,
+  registerDecorator,
+  setImportNameOverride,
+  setVuexNamespace,
+} from "./registry.js";
 import { runTransforms } from "./transformer.js";
 
 const debug = Debug("vuedc:convert");
@@ -17,12 +22,15 @@ export function convertAst(source: ts.SourceFile, program: ts.Program) {
   const outsideStatements = getOutsideStatements(source);
   registerTopLevelVars(outsideStatements);
   registerImportNameOverrides(outsideStatements);
+  registerVuexNamespaces(outsideStatements);
 
   const unwantedStatements = (s: ts.Statement) => {
     const pkg = getPackageName(s);
     if (pkg && vccPackages.includes(pkg)) return true;
     if (pkg === "vue") return true;
+    if (getNamespaceStatement(s)) return true;
   };
+  debug("Removing unwanted imports");
   const filteredOutsideStatements = outsideStatements.filter((s) => !unwantedStatements(s));
 
   debug("Running transforms");
@@ -39,6 +47,31 @@ export function convertAst(source: ts.SourceFile, program: ts.Program) {
   const newSourceFile = ts.factory.updateSourceFile(source, resultStatements);
   const result = printer.printFile(newSourceFile);
   return result;
+}
+
+function registerVuexNamespaces(statements: ts.Statement[]) {
+  statements.forEach((s) => {
+    const ns = getNamespaceStatement(s);
+    if (!ns) return;
+
+    const namespace = ns.initializer.arguments[0];
+    if (!namespace || (!ts.isStringLiteral(namespace) && !ts.isIdentifier(namespace))) return;
+    setVuexNamespace(ns.name.text, namespace);
+    registerDecorator(ns.name.text);
+  });
+}
+
+function getNamespaceStatement(statement: ts.Statement) {
+  const namespaceDecl = getImportNameOverride("namespace") ?? "namespace";
+  if (!ts.isVariableStatement(statement)) return false;
+  if (statement.declarationList.declarations.length !== 1) return false;
+  const declaration = statement.declarationList.declarations[0];
+  if (!ts.isIdentifier(declaration.name)) return false;
+  if (!declaration.initializer || !ts.isCallExpression(declaration.initializer)) return false;
+  const expr = declaration.initializer.expression;
+  if (!ts.isIdentifier(expr)) return false;
+  if (expr.text !== namespaceDecl) return false;
+  return { name: declaration.name, initializer: declaration.initializer };
 }
 
 function registerImportNameOverrides(statements: ts.Statement[]) {

--- a/client/src/helpers/tsHelpers.ts
+++ b/client/src/helpers/tsHelpers.ts
@@ -17,11 +17,21 @@ export function getDecorators(node: ts.Node, name: string) {
   if (!ts.canHaveDecorators(node)) return undefined;
 
   const decorators = ts.getDecorators(node) ?? [];
-  return decorators.filter((decorator) =>
-    ts.isCallExpression(decorator.expression)
-      ? decorator.expression.expression.getText() === name
-      : decorator.expression.getText() === name,
-  );
+  return decorators.filter((decorator) => {
+    let expr = decorator.expression;
+    if (ts.isCallExpression(expr)) {
+      if (!ts.isIdentifier(expr.expression) && !ts.isPropertyAccessExpression(expr.expression)) {
+        return false;
+      }
+      expr = expr.expression;
+    }
+
+    if (ts.isPropertyAccessExpression(expr)) {
+      return expr.name.text === name;
+    } else if (ts.isIdentifier(expr)) {
+      return expr.text === name;
+    }
+  });
 }
 
 export function getPackageName(node: ts.Node) {
@@ -225,6 +235,10 @@ export function isObjLitExpr(node: ts.Node | unknown): node is ts.ObjectLiteralE
 
 export function isStringLit(node: ts.Node | unknown): node is ts.StringLiteral {
   return isTypeOfNode<ts.StringLiteral>(node, "isStringLiteral");
+}
+
+export function isId(node: ts.Node | unknown): node is ts.Identifier {
+  return isTypeOfNode<ts.Identifier>(node, "isIdentifier");
 }
 
 export function isPropertyAccessExpr(node: ts.Node | unknown): node is ts.PropertyAccessExpression {

--- a/client/src/registry.ts
+++ b/client/src/registry.ts
@@ -1,4 +1,5 @@
 import Debug from "debug";
+import ts from "typescript";
 const debug = Debug("vuedc:registry");
 /**
  * Global registry singleton for file level metadata that can be useful
@@ -13,6 +14,7 @@ class Registry {
   collisions = new Map<string, { tag: string; sources: Set<string> }>();
   importNameOverrides = new Map<string, string>();
   warnings = new Set<string>();
+  vuexNamespacedDecorators = new Map<string, ts.StringLiteral | ts.Identifier>();
 }
 const registry = new Registry();
 
@@ -25,6 +27,7 @@ export function resetRegistry() {
   registry.importNameOverrides.clear();
   registry.collisions.clear();
   registry.warnings.clear();
+  registry.vuexNamespacedDecorators.clear();
 }
 
 export function isDecoratorRegistered(decorator: string) {
@@ -107,4 +110,14 @@ export function addGlobalWarning(message: string) {
 
 export function getGlobalWarnings() {
   return [...registry.warnings];
+}
+
+export function setVuexNamespace(decorator: string, namespace: ts.StringLiteral | ts.Identifier) {
+  debug(`Setting vuex namespace for @${decorator}: ${namespace.text}`);
+  registry.vuexNamespacedDecorators.set(decorator, namespace);
+}
+
+export function getVuexNamespace(decorator: string) {
+  debug(`Getting vuex namespace for @${decorator}`);
+  return registry.vuexNamespacedDecorators.get(decorator);
 }

--- a/client/src/transformer.ts
+++ b/client/src/transformer.ts
@@ -17,9 +17,9 @@ export function runTransforms(
   debug("Running transforms");
   const results = getAstResults(node, program);
 
-  const outsideImports = outsideStatements.filter((s) =>
+  const outsideImports = outsideStatements.filter((s): s is ts.ImportDeclaration =>
     ts.isImportDeclaration(s),
-  ) as ts.ImportDeclaration[];
+  );
   const outsideStatementsWithoutImports = outsideStatements.filter(
     (s) => !ts.isImportDeclaration(s),
   );

--- a/client/src/transformer/transforms/utils/isValidIdentifier.ts
+++ b/client/src/transformer/transforms/utils/isValidIdentifier.ts
@@ -1,3 +1,9 @@
+/**
+ * Determines if a given identifier can be used in a property access expression
+ * or if it needs to use an element access expression.
+ * @param identifier
+ * @returns
+ */
 export function isValidIdentifier(identifier: unknown) {
   return (
     typeof identifier === "string" &&

--- a/client/src/transformer/transforms/vuex-class/Getter.ts
+++ b/client/src/transformer/transforms/vuex-class/Getter.ts
@@ -1,3 +1,145 @@
-import { convertVuexComputedFactory } from "./utils/convertVuexComputedFactory";
+import { createIdentifier, isStringLit } from "@/helpers/tsHelpers";
+import ts from "typescript";
+import { isValidIdentifier } from "../utils/isValidIdentifier";
+import {
+  VuexPropertyTypeBase,
+  convertVuexComputedFactory,
+} from "./utils/convertVuexComputedFactory";
 
-export const transformVuexGetter = convertVuexComputedFactory("Getter", "getters");
+export const transformVuexGetter = convertVuexComputedFactory("Getter", getAccessExpression);
+
+/**
+ * - `string` indicates that the class property name is being used as the store property name
+ * ```ts
+ *    ⁣@Getter() foo: boolean; // string : 'foo'
+ * ```
+ * - `Identifier` indicates that a variable has been passed as a parameter to the decorator
+ * ```ts
+ *    ⁣@Getter(bar) foo: boolean; // Identifier : bar
+ * ```
+ * - `StringLiteral` indicates that a string has been passed as a parameter to the decorator
+ * ```ts
+ *    ⁣@Getter('bar') foo: boolean; // StringLiteral : 'bar'
+ * ```
+ * - `BinaryExpression` indicates that a string concatenation has been passed as a parameter to the decorator
+ * ```ts
+ *    ⁣@Getter('foo/' + bar) foo: boolean; // BinaryExpression : 'foo/' + bar
+ * ```
+ */
+type VuexGetterPropertyType = VuexPropertyTypeBase;
+
+function getAccessExpression(
+  property: string | ts.Expression,
+  namespace?: ts.Identifier | ts.StringLiteral,
+) {
+  if (
+    typeof property !== "string" &&
+    !ts.isIdentifier(property) &&
+    !ts.isStringLiteral(property) &&
+    !ts.isBinaryExpression(property)
+  ) {
+    throw new Error(
+      `[vuex-class] Unexpected decorator argument, expected String or Identifier got ${
+        ts.SyntaxKind[property.kind]
+      }`,
+    );
+  }
+  return getGetterAccessExpression(property, namespace);
+}
+
+function getGetterAccessExpression(
+  property: VuexGetterPropertyType,
+  namespace?: ts.StringLiteral | ts.Identifier,
+) {
+  const storeId = createIdentifier("store");
+  const storePropertyId = createIdentifier("getters");
+  const storeGetterAcs = ts.factory.createPropertyAccessExpression(storeId, storePropertyId);
+
+  if (!namespace) {
+    // Kind of feel like this is a perfect use case for a switch(true) statement
+    // but TS doesn't type narrow them yet
+
+    // @Getter foo: string; -> store.getters.foo
+    if (typeof property === "string") {
+      return ts.factory.createPropertyAccessExpression(storeGetterAcs, property);
+    }
+
+    // @Getter('foo/' + bar) foo: string; -> store.getters['foo/' + bar]
+    if (ts.isBinaryExpression(property)) {
+      return ts.factory.createElementAccessExpression(storeGetterAcs, property);
+    }
+
+    // @Getter(if (namespace) someVar) foo: string; -> store.getters[someVar]
+    if (ts.isIdentifier(property))
+      return ts.factory.createElementAccessExpression(storeGetterAcs, property);
+
+    // @Getter foo: string; -> store.getters.foo
+    if (isValidIdentifier(property.text)) {
+      return ts.factory.createPropertyAccessExpression(storeGetterAcs, property.text);
+    }
+
+    // @Getter('foo/bar') foo: string; -> store.getters['foo/bar']
+    return ts.factory.createElementAccessExpression(storeGetterAcs, property);
+  }
+
+  if (typeof property === "string" || ts.isStringLiteral(property)) {
+    // const ns1 = namespace('moduleB');
+    // @ns1.Getter foo: string; -> store.getters['moduleB/foo']
+    // @ns1.Getter('foo/bar') foo: string; -> store.getters['moduleB/foo/bar']
+    // const ns2 = namespace(moduleC);
+    // @ns2.Getter foo: string; -> store.getters[`${moduleC}/foo`]
+    // @ns2.Getter('foo/bar') foo: string; -> store.getters[`${moduleC}/foo/bar`]
+    const prop = isStringLit(property) ? property : ts.factory.createStringLiteral(property);
+    const nsProp = namespacedGetterProperty(namespace, prop);
+    return ts.factory.createElementAccessExpression(storeGetterAcs, nsProp);
+  }
+
+  if (ts.isBinaryExpression(property)) {
+    // const ns = namespace('moduleB');
+    // @ns.Getter('foo/' + bar) foo: string; -> ERROR
+    throw new Error("Mixing namespace and binary expressions is not supported");
+  }
+
+  // const ns1 = namespace('moduleB');
+  // @ns1.Getter(someVar) foo: string; -> store.getters[`moduleB/${someVar}`]
+  // const ns2 = namespace(moduleC);
+  // @ns2.Getter(someVar) foo: string; -> store.getters[`${moduleC}/${someVar}`]
+  const nsProp = namespacedGetterProperty(namespace, property);
+  return ts.factory.createElementAccessExpression(storeGetterAcs, nsProp);
+}
+
+function namespacedGetterProperty(
+  namespace: ts.Identifier | ts.StringLiteral,
+  property: ts.Identifier | ts.StringLiteral,
+) {
+  if (ts.isStringLiteral(namespace) && ts.isStringLiteral(property)) {
+    // -> "moduleB/foo"
+    return ts.factory.createStringLiteral(namespace.text + "/" + property.text);
+  }
+
+  if (ts.isStringLiteral(namespace) && ts.isIdentifier(property)) {
+    // -> `moduleB/${foo}`
+    const templateHead = ts.factory.createTemplateHead(namespace.text + "/");
+    const templateSpan = ts.factory.createTemplateSpan(property, ts.factory.createTemplateTail(""));
+    return ts.factory.createTemplateExpression(templateHead, [templateSpan]);
+  }
+
+  if (ts.isIdentifier(namespace) && ts.isIdentifier(property)) {
+    // -> `${moduleB}/${foo}`
+    const templateHead = ts.factory.createTemplateHead("");
+    const namespaceSpan = ts.factory.createTemplateSpan(
+      namespace,
+      ts.factory.createTemplateMiddle("/"),
+    );
+    const templateSpan = ts.factory.createTemplateSpan(property, ts.factory.createTemplateTail(""));
+    return ts.factory.createTemplateExpression(templateHead, [namespaceSpan, templateSpan]);
+  }
+
+  // -> `${moduleB}/foo`
+  const templateHeaded = ts.factory.createTemplateHead("");
+  const namespaceSpan = ts.factory.createTemplateSpan(
+    namespace,
+    ts.factory.createTemplateTail(`/${property.text}`),
+  );
+  return ts.factory.createTemplateExpression(templateHeaded, [namespaceSpan]);
+}

--- a/client/src/transformer/transforms/vuex-class/State.ts
+++ b/client/src/transformer/transforms/vuex-class/State.ts
@@ -1,3 +1,175 @@
-import { convertVuexComputedFactory } from "./utils/convertVuexComputedFactory";
+import { createIdentifier, isArrowFunc } from "@/helpers/tsHelpers";
+import { cloneNode } from "ts-clone-node";
+import ts from "typescript";
+import { isValidIdentifier } from "../utils/isValidIdentifier";
+import {
+  VuexPropertyTypeBase,
+  convertVuexComputedFactory,
+} from "./utils/convertVuexComputedFactory";
 
-export const transformVuexState = convertVuexComputedFactory("State", "state");
+export const transformVuexState = convertVuexComputedFactory("State", getAccessExpression);
+
+/**
+ * - `string` indicates that the class property name is being used as the store property name
+ * ```ts
+ *    ⁣@State() foo: boolean; // string : 'foo'
+ * ```
+ * - `Identifier` indicates that a variable has been passed as a parameter to the decorator
+ * ```ts
+ *    ⁣@State(bar) foo: boolean; // Identifier : bar
+ * ```
+ * - `StringLiteral` indicates that a string has been passed as a parameter to the decorator
+ * ```ts
+ *    ⁣@State('bar') foo: boolean; // StringLiteral : 'bar'
+ * ```
+ * - `BinaryExpression` indicates that a string concatenation has been passed as a parameter to the decorator
+ * ```ts
+ *    ⁣@State('foo/' + bar) foo: boolean; // BinaryExpression : 'foo/' + bar
+ * ```
+ * - `ArrowFunction` indicates that an arrow function has been passed as a parameter to the decorator
+ * ```ts
+ *    ⁣@State(s => s.foo.bar) foo: boolean; // ArrowFunction : s => s.foo.bar
+ * ```
+ */
+type VuexStatePropertyType = VuexPropertyTypeBase | ts.ArrowFunction;
+
+/**
+ * Converts the decorator id to an arrow function with an access expression
+ * @param property
+ *
+ * ```ts
+ * ⁣@State("foo") bar: string; -> (): string => store.state.foo
+ * ⁣@Getter("ns/foo") bar: boolean; -> (): boolean => store.getters["ns/foo"]
+ * ```
+ */
+function getAccessExpression(
+  property: string | ts.Expression,
+  namespace?: ts.Identifier | ts.StringLiteral,
+) {
+  if (
+    typeof property !== "string" &&
+    !ts.isIdentifier(property) &&
+    !ts.isStringLiteral(property) &&
+    !ts.isBinaryExpression(property) &&
+    !isArrowFunc(property)
+  ) {
+    throw new Error(
+      `[vuex-class] Unexpected decorator argument, expected String or Identifier or Arrow Function got ${
+        ts.SyntaxKind[property.kind]
+      }`,
+    );
+  }
+  return getStateAccessExpression(property, namespace);
+}
+
+function getStateAccessExpression(
+  property: VuexStatePropertyType,
+  namespace?: ts.StringLiteral | ts.Identifier,
+) {
+  // @State(s => s.foo.bar) bar: string; -> store.state.foo.bar
+  // const ns = namespace('myNamespace');
+  // @ns.State(s => s.foo.bar) bar: string; -> store.state.myNamespace.foo.bar
+  // const ns = namespace(nsVar);
+  // @ns.State(s => s.foo.bar) bar: string; -> store.state[nsVar].foo.bar
+  if (isArrowFunc(property)) {
+    const transformer = getArrowFnTransformer(property, namespace);
+    const transformedArrowFn = ts.transform(property, [transformer]).transformed[0];
+    const accessExpr = cloneNode(transformedArrowFn.body) as ts.PropertyAccessExpression;
+    return accessExpr;
+  }
+
+  const storeId = createIdentifier("store");
+  const storePropId = createIdentifier("state");
+  const storePropAcs = ts.factory.createPropertyAccessExpression(storeId, storePropId);
+
+  if (
+    typeof property !== "string" &&
+    (ts.isIdentifier(property) || ts.isBinaryExpression(property))
+  ) {
+    // @State(someVar) foo: string; -> store.state[someVar]
+    if (!namespace) return ts.factory.createElementAccessExpression(storePropAcs, property);
+
+    let storeStateNsAsc: ts.AccessExpression | undefined;
+    // const ns = namespace('moduleB');
+    // @ns.State(someVar) foo: string; -> store.state.moduleB[someVar]
+    if (ts.isStringLiteral(namespace)) {
+      const nsId = createIdentifier(namespace.text);
+      storeStateNsAsc = ts.factory.createPropertyAccessExpression(storePropAcs, nsId);
+    } else {
+      // const ns = namespace(moduleC);
+      // @ns.State(someVar) foo: string; -> store.state[moduleC][someVar]
+      storeStateNsAsc = ts.factory.createElementAccessExpression(storePropAcs, namespace);
+    }
+    return ts.factory.createElementAccessExpression(storeStateNsAsc, property);
+  }
+
+  let prop = typeof property !== "string" ? property.text : property;
+
+  if (!isValidIdentifier(prop)) {
+    // @State('ns/foo') bar: string; -> store.state['ns/foo']
+    if (namespace) throw new Error("Mixing namespace and binary expressions is not supported");
+    const propertyId = ts.factory.createStringLiteral(prop);
+    return ts.factory.createElementAccessExpression(storePropAcs, propertyId);
+  }
+
+  // @State('foo') bar: string; -> store.state.foo
+  const propertyId = createIdentifier(prop);
+  if (!namespace) return ts.factory.createPropertyAccessExpression(storePropAcs, propertyId);
+  // const ns = namespace('moduleB');
+  // @ns.State('foo') bar: string; -> store.state.moduleB.foo
+  if (ts.isStringLiteral(namespace)) {
+    const nsId = createIdentifier(namespace.text);
+    const storePropNsAcs = ts.factory.createPropertyAccessExpression(storePropAcs, nsId);
+    return ts.factory.createPropertyAccessExpression(storePropNsAcs, propertyId);
+  }
+  // const ns = namespace(moduleC);
+  // @ns.State('foo') bar: string; -> store.state[moduleC].foo
+  const storePropNsAcs = ts.factory.createElementAccessExpression(storePropAcs, namespace);
+  return ts.factory.createPropertyAccessExpression(storePropNsAcs, propertyId);
+}
+
+/**
+ * Takes an arrow function, visits each node of the PropertyAccessExpression
+ * until it files the arrow function parameter identifier and replaces it with
+ * the store.<propertyName>
+ *
+ * TODO this currently only supports a concise body, I don't wanna deal with more complex bodies
+ *
+ * @example
+ * (s) => s.foo.bar; // -> store.state.foo.bar
+ */
+function getArrowFnTransformer(
+  arrowFn: ts.ArrowFunction,
+  namespace?: ts.Identifier | ts.StringLiteral,
+) {
+  const [param] = arrowFn.parameters;
+  if (!param) throw new Error("Expected an arrow function with a single parameter");
+  const storeId = createIdentifier("store");
+  const propertyId = createIdentifier("state");
+  let storeStateAccess: ts.AccessExpression = ts.factory.createPropertyAccessExpression(
+    storeId,
+    propertyId,
+  );
+
+  if (namespace) {
+    if (ts.isStringLiteral(namespace)) {
+      storeStateAccess = ts.factory.createPropertyAccessExpression(
+        storeStateAccess,
+        namespace.text,
+      );
+    } else {
+      storeStateAccess = ts.factory.createElementAccessExpression(storeStateAccess, namespace);
+    }
+  }
+
+  return ((ctx) => {
+    const visitor = (node: ts.Node): ts.Node => {
+      if (ts.isIdentifier(node) && node.getText() === param.name.getText()) {
+        return storeStateAccess;
+      }
+      return ts.visitEachChild(node, visitor, ctx);
+    };
+
+    return (node) => ts.visitNode(arrowFn, visitor);
+  }) as ts.TransformerFactory<ts.ArrowFunction>;
+}

--- a/client/src/transformer/transforms/vuex-class/State.ts
+++ b/client/src/transformer/transforms/vuex-class/State.ts
@@ -2,36 +2,10 @@ import { createIdentifier, isArrowFunc } from "@/helpers/tsHelpers";
 import { cloneNode } from "ts-clone-node";
 import ts from "typescript";
 import { isValidIdentifier } from "../utils/isValidIdentifier";
-import {
-  VuexPropertyTypeBase,
-  convertVuexComputedFactory,
-} from "./utils/convertVuexComputedFactory";
+import { convertVuexComputedFactory } from "./utils/convertVuexComputedFactory";
+import { VuexStatePropertyType } from "./utils/vuexClass.types";
 
 export const transformVuexState = convertVuexComputedFactory("State", getAccessExpression);
-
-/**
- * - `string` indicates that the class property name is being used as the store property name
- * ```ts
- *    ⁣@State() foo: boolean; // string : 'foo'
- * ```
- * - `Identifier` indicates that a variable has been passed as a parameter to the decorator
- * ```ts
- *    ⁣@State(bar) foo: boolean; // Identifier : bar
- * ```
- * - `StringLiteral` indicates that a string has been passed as a parameter to the decorator
- * ```ts
- *    ⁣@State('bar') foo: boolean; // StringLiteral : 'bar'
- * ```
- * - `BinaryExpression` indicates that a string concatenation has been passed as a parameter to the decorator
- * ```ts
- *    ⁣@State('foo/' + bar) foo: boolean; // BinaryExpression : 'foo/' + bar
- * ```
- * - `ArrowFunction` indicates that an arrow function has been passed as a parameter to the decorator
- * ```ts
- *    ⁣@State(s => s.foo.bar) foo: boolean; // ArrowFunction : s => s.foo.bar
- * ```
- */
-type VuexStatePropertyType = VuexPropertyTypeBase | ts.ArrowFunction;
 
 /**
  * Converts the decorator id to an arrow function with an access expression

--- a/client/src/transformer/transforms/vuex-class/__tests__/Action.test.ts
+++ b/client/src/transformer/transforms/vuex-class/__tests__/Action.test.ts
@@ -7,17 +7,25 @@ describe("Action decorator", () => {
     const { ast, program } = getSingleFileProgram(`
       import {Component} from 'vue-property-decorator';
       import {Action} from 'vuex-class';
+      const ns1 = namespace('moduleB');
+      const moduleC = 'moduleC';
+      const ns2 = namespace(moduleC);
       @Component
       export default class Foo {
         @Action foo: () => void;
+        @ns1.Action baz: () => void;
+        @ns2.Action qux: () => void;
       }
     `);
     const result = convertAst(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
+      const moduleC = 'moduleC';
       const store = useStore();
       const foo = async (): Promise<void> => store.dispatch(\\"foo\\");
+      const baz = async (): Promise<void> => store.dispatch(\\"moduleB/baz\\");
+      const qux = async (): Promise<void> => store.dispatch(\`\${moduleC}/qux\`);
       "
     `);
   });
@@ -26,17 +34,25 @@ describe("Action decorator", () => {
     const { ast, program } = getSingleFileProgram(`
       import {Component} from 'vue-property-decorator';
       import {Action} from 'vuex-class';
+      const ns1 = namespace('moduleB');
+      const moduleC = 'moduleC';
+      const ns2 = namespace(moduleC);
       @Component
       export default class Foo {
         @Action('bar') foo: () => void;
+        @ns1.Action('bar') baz: () => void;
+        @ns2.Action('bar') qux: () => void;
       }
     `);
     const result = convertAst(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
+      const moduleC = 'moduleC';
       const store = useStore();
       const foo = async (): Promise<void> => store.dispatch('bar');
+      const baz = async (): Promise<void> => store.dispatch(\\"moduleB/bar\\");
+      const qux = async (): Promise<void> => store.dispatch(\`\${moduleC}/bar\`);
       "
     `);
   });
@@ -45,17 +61,25 @@ describe("Action decorator", () => {
     const { ast, program } = getSingleFileProgram(`
       import {Component} from 'vue-property-decorator';
       import {Action} from 'vuex-class';
+      const ns1 = namespace('moduleB');
+      const moduleC = 'moduleC';
+      const ns2 = namespace(moduleC);
       @Component
       export default class Foo {
         @Action('baz/foo') foo: () => void;
+        @ns1.Action('baz/foo') baz: () => void;
+        @ns2.Action('baz/foo') qux: () => void;
       }
     `);
     const result = convertAst(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
+      const moduleC = 'moduleC';
       const store = useStore();
       const foo = async (): Promise<void> => store.dispatch('baz/foo');
+      const baz = async (): Promise<void> => store.dispatch(\\"moduleB/baz/foo\\");
+      const qux = async (): Promise<void> => store.dispatch(\`\${moduleC}/baz/foo\`);
       "
     `);
   });
@@ -64,17 +88,25 @@ describe("Action decorator", () => {
     const { ast, program } = getSingleFileProgram(`
       import {Component} from 'vue-property-decorator';
       import {Action} from 'vuex-class';
+      const ns1 = namespace('moduleB');
+      const moduleC = 'moduleC';
+      const ns2 = namespace(moduleC);
       @Component
       export default class Foo {
         @Action('baz/foo') foo: () => string;
+        @ns1.Action('baz/foo') baz: () => string;
+        @ns2.Action('baz/foo') qux: () => string;
       }
     `);
     const result = convertAst(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
+      const moduleC = 'moduleC';
       const store = useStore();
       const foo = async (): Promise<string> => store.dispatch('baz/foo');
+      const baz = async (): Promise<string> => store.dispatch(\\"moduleB/baz/foo\\");
+      const qux = async (): Promise<string> => store.dispatch(\`\${moduleC}/baz/foo\`);
       "
     `);
   });
@@ -83,19 +115,27 @@ describe("Action decorator", () => {
     const { ast, program } = getSingleFileProgram(`
       import {Component} from 'vue-property-decorator';
       import {Action} from 'vuex-class';
+      const ns1 = namespace('moduleB');
+      const moduleC = 'moduleC';
+      const ns2 = namespace(moduleC);
       const foo = 'foo';
       @Component
       export default class Foo {
         @Action(foo) bar: (a: string) => void;
+        @ns1.Action(foo) baz: (a: string) => void;
+        @ns2.Action(foo) qux: (a: string) => void;
       }
     `);
     const result = convertAst(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
+      const moduleC = 'moduleC';
       const foo = 'foo';
       const store = useStore();
       const bar = async (a: string): Promise<void> => store.dispatch(foo, a);
+      const baz = async (a: string): Promise<void> => store.dispatch(\`moduleB/\${foo}\`, a);
+      const qux = async (a: string): Promise<void> => store.dispatch(\`\${moduleC}/\${foo}\`, a);
       "
     `);
   });
@@ -104,28 +144,39 @@ describe("Action decorator", () => {
     const { ast, program } = getSingleFileProgram(`
       import {Component} from 'vue-property-decorator';
       import {Action} from 'vuex-class';
+      const ns1 = namespace('moduleB');
+      const moduleC = 'moduleC';
+      const ns2 = namespace(moduleC);
       @Component
       export default class Foo {
         @Action foo;
+        @ns1.Action baz;
+        @ns2.Action qux;
       }
     `);
     const result = convertAst(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
+      const moduleC = 'moduleC';
       const store = useStore();
       /* [VUEDC_TODO]: Check function dispatch call signature.*/ const foo = async (...args: unknown[]): Promise<unknown> => store.dispatch(\\"foo\\", args);
+      /* [VUEDC_TODO]: Check function dispatch call signature.*/ const baz = async (...args: unknown[]): Promise<unknown> => store.dispatch(\\"moduleB/baz\\", args);
+      /* [VUEDC_TODO]: Check function dispatch call signature.*/ const qux = async (...args: unknown[]): Promise<unknown> => store.dispatch(\`\${moduleC}/qux\`, args);
       "
     `);
   });
 
-  it("should throw if duplicate action decorator", () => {
+  it.each(["", "ns1.", "ns2."])("should throw if duplicate action decorator", (prefix) => {
     const { ast, program } = getSingleFileProgram(`
       import {Component} from 'vue-property-decorator';
-      import {Action} from 'vuex-class';
+      import {Action, namespace} from 'vuex-class';
+      const ns1 = namespace('moduleB');
+      const moduleC = 'moduleC';
+      const ns2 = namespace(moduleC);
       @Component
       export default class Foo {
-        @Action @Action foo: () => void;
+        @${prefix}Action @${prefix}Action foo: () => void;
       }
     `);
     expect(() => convertAst(ast, program)).toThrowError(
@@ -133,17 +184,20 @@ describe("Action decorator", () => {
     );
   });
 
-  it("should throw if function signature contains more than 1 parameter", () => {
-    const { ast, program } = getSingleFileProgram(`
+  it.each(["", "ns1.", "ns2."])(
+    "should throw if function signature contains more than 1 parameter",
+    (prefix) => {
+      const { ast, program } = getSingleFileProgram(`
       import {Component} from 'vue-property-decorator';
       import {Action} from 'vuex-class';
       @Component
       export default class Foo {
-        @Action foo: (a: string, b: string) => void;
+        @${prefix}Action foo: (a: string, b: string) => void;
       }
     `);
-    expect(() => convertAst(ast, program)).toThrowError(
-      "[vuex-class] foo dispatch signature has more than 1 parameter.",
-    );
-  });
+      expect(() => convertAst(ast, program)).toThrowError(
+        "[vuex-class] foo dispatch signature has more than 1 parameter.",
+      );
+    },
+  );
 });

--- a/client/src/transformer/transforms/vuex-class/__tests__/Mutation.test.ts
+++ b/client/src/transformer/transforms/vuex-class/__tests__/Mutation.test.ts
@@ -7,17 +7,25 @@ describe("Mutation decorator", () => {
     const { ast, program } = getSingleFileProgram(`
       import {Component} from 'vue-property-decorator';
       import {Mutation} from 'vuex-class';
+      const ns1 = namespace('moduleB');
+      const moduleC = 'moduleC';
+      const ns2 = namespace(moduleC);
       @Component
       export default class Foo {
         @Mutation foo: () => void;
+        @ns1.Mutation baz: () => void;
+        @ns2.Mutation qux: () => void;
       }
     `);
     const result = convertAst(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
+      const moduleC = 'moduleC';
       const store = useStore();
       const foo = (): void => store.commit(\\"foo\\");
+      const baz = (): void => store.commit(\\"moduleB/baz\\");
+      const qux = (): void => store.commit(\`\${moduleC}/qux\`);
       "
     `);
   });
@@ -26,17 +34,25 @@ describe("Mutation decorator", () => {
     const { ast, program } = getSingleFileProgram(`
       import {Component} from 'vue-property-decorator';
       import {Mutation} from 'vuex-class';
+      const ns1 = namespace('moduleB');
+      const moduleC = 'moduleC';
+      const ns2 = namespace(moduleC);
       @Component
       export default class Foo {
         @Mutation('bar') foo: () => void;
+        @ns1.Mutation('bar') baz: () => void;
+        @ns2.Mutation('bar') qux: () => void;
       }
     `);
     const result = convertAst(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
+      const moduleC = 'moduleC';
       const store = useStore();
       const foo = (): void => store.commit('bar');
+      const baz = (): void => store.commit(\\"moduleB/bar\\");
+      const qux = (): void => store.commit(\`\${moduleC}/bar\`);
       "
     `);
   });
@@ -45,17 +61,25 @@ describe("Mutation decorator", () => {
     const { ast, program } = getSingleFileProgram(`
       import {Component} from 'vue-property-decorator';
       import {Mutation} from 'vuex-class';
+      const ns1 = namespace('moduleB');
+      const moduleC = 'moduleC';
+      const ns2 = namespace(moduleC);
       @Component
       export default class Foo {
         @Mutation('baz/foo') foo: () => void;
+        @ns1.Mutation('baz/foo') baz: () => void;
+        @ns2.Mutation('baz/foo') qux: () => void;
       }
     `);
     const result = convertAst(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
+      const moduleC = 'moduleC';
       const store = useStore();
       const foo = (): void => store.commit('baz/foo');
+      const baz = (): void => store.commit(\\"moduleB/baz/foo\\");
+      const qux = (): void => store.commit(\`\${moduleC}/baz/foo\`);
       "
     `);
   });
@@ -64,19 +88,27 @@ describe("Mutation decorator", () => {
     const { ast, program } = getSingleFileProgram(`
       import {Component} from 'vue-property-decorator';
       import {Mutation} from 'vuex-class';
+      const ns1 = namespace('moduleB');
+      const moduleC = 'moduleC';
+      const ns2 = namespace(moduleC);
       @Component
       export default class Foo {
         // This is bad practice, mutations should not return anything
         @Mutation('baz/foo') foo: () => string;
+        @ns1.Mutation('baz/foo') baz: () => string;
+        @ns2.Mutation('baz/foo') qux: () => string;
       }
     `);
     const result = convertAst(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
+      const moduleC = 'moduleC';
       const store = useStore();
       // This is bad practice, mutations should not return anything
       const foo = (): string => store.commit('baz/foo');
+      const baz = (): string => store.commit(\\"moduleB/baz/foo\\");
+      const qux = (): string => store.commit(\`\${moduleC}/baz/foo\`);
       "
     `);
   });
@@ -85,19 +117,27 @@ describe("Mutation decorator", () => {
     const { ast, program } = getSingleFileProgram(`
       import {Component} from 'vue-property-decorator';
       import {Mutation} from 'vuex-class';
+      const ns1 = namespace('moduleB');
+      const moduleC = 'moduleC';
+      const ns2 = namespace(moduleC);
       const foo = 'foo';
       @Component
       export default class Foo {
         @Mutation(foo) bar: (a: string) => void;
+        @ns1.Mutation(foo) baz: (a: string) => void;
+        @ns2.Mutation(foo) qux: (a: string) => void;
       }
     `);
     const result = convertAst(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
+      const moduleC = 'moduleC';
       const foo = 'foo';
       const store = useStore();
       const bar = (a: string): void => store.commit(foo, a);
+      const baz = (a: string): void => store.commit(\`moduleB/\${foo}\`, a);
+      const qux = (a: string): void => store.commit(\`\${moduleC}/\${foo}\`, a);
       "
     `);
   });
@@ -106,28 +146,39 @@ describe("Mutation decorator", () => {
     const { ast, program } = getSingleFileProgram(`
       import {Component} from 'vue-property-decorator';
       import {Mutation} from 'vuex-class';
+      const ns1 = namespace('moduleB');
+      const moduleC = 'moduleC';
+      const ns2 = namespace(moduleC);
       @Component
       export default class Foo {
         @Mutation foo;
+        @ns1.Mutation baz;
+        @ns2.Mutation qux;
       }
     `);
     const result = convertAst(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
+      const moduleC = 'moduleC';
       const store = useStore();
       /* [VUEDC_TODO]: Check function commit call signature.*/ const foo = (...args: unknown[]): unknown => store.commit(\\"foo\\", args);
+      /* [VUEDC_TODO]: Check function commit call signature.*/ const baz = (...args: unknown[]): unknown => store.commit(\\"moduleB/baz\\", args);
+      /* [VUEDC_TODO]: Check function commit call signature.*/ const qux = (...args: unknown[]): unknown => store.commit(\`\${moduleC}/qux\`, args);
       "
     `);
   });
 
-  it("should throw if duplicate mutation decorator", () => {
+  it.each(["", "ns1.", "ns2."])("should throw if duplicate mutation decorator", (prefix) => {
     const { ast, program } = getSingleFileProgram(`
       import {Component} from 'vue-property-decorator';
       import {Mutation} from 'vuex-class';
+      const ns1 = namespace('moduleB');
+      const moduleC = 'moduleC';
+      const ns2 = namespace(moduleC);
       @Component
       export default class Foo {
-        @Mutation @Mutation foo: () => void;
+        @${prefix}Mutation @${prefix}Mutation foo: () => void;
       }
     `);
     expect(() => convertAst(ast, program)).toThrowError(
@@ -135,17 +186,23 @@ describe("Mutation decorator", () => {
     );
   });
 
-  it("should throw if function signature contains more than 1 parameter", () => {
-    const { ast, program } = getSingleFileProgram(`
+  it.each(["", "ns1.", "ns2."])(
+    "should throw if function signature contains more than 1 parameter",
+    (prefix) => {
+      const { ast, program } = getSingleFileProgram(`
       import {Component} from 'vue-property-decorator';
       import {Mutation} from 'vuex-class';
+      const ns1 = namespace('moduleB');
+      const moduleC = 'moduleC';
+      const ns2 = namespace(moduleC);
       @Component
       export default class Foo {
-        @Mutation foo: (a: string, b: string) => void;
+        @${prefix}Mutation foo: (a: string, b: string) => void;
       }
     `);
-    expect(() => convertAst(ast, program)).toThrowError(
-      "[vuex-class] foo commit signature has more than 1 parameter.",
-    );
-  });
+      expect(() => convertAst(ast, program)).toThrowError(
+        "[vuex-class] foo commit signature has more than 1 parameter.",
+      );
+    },
+  );
 });

--- a/client/src/transformer/transforms/vuex-class/__tests__/State.test.ts
+++ b/client/src/transformer/transforms/vuex-class/__tests__/State.test.ts
@@ -6,10 +6,15 @@ describe("State decorator", () => {
   it("should transform state", () => {
     const { ast, program } = getSingleFileProgram(`
       import { Component, Vue } from 'vue-property-decorator';
-      import { State } from 'vuex-class';
+      import { State, namespace } from 'vuex-class';
+      const ns1 = namespace('moduleB');
+      const moduleC = 'moduleC';
+      const ns2 = namespace(moduleC);
       @Component
       export default class Foo {
         @State bar: string;
+        @ns1.State baz: string;
+        @ns2.State qux: string;
       }
     `);
     const result = convertAst(ast, program);
@@ -17,13 +22,74 @@ describe("State decorator", () => {
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
       import { computed } from \\"vue\\";
+      const moduleC = 'moduleC';
       const store = useStore();
       const bar = computed<string>(() => store.state.bar);
+      const baz = computed<string>(() => store.state.moduleB.baz);
+      const qux = computed<string>(() => store.state[moduleC].qux);
       "
     `);
   });
 
-  it("should transform state with namespace", () => {
+  it("should transform state with string property argument", () => {
+    const { ast, program } = getSingleFileProgram(`
+      import { Component, Vue } from 'vue-property-decorator';
+      import { State } from 'vuex-class';
+      const ns1 = namespace('moduleB');
+      const moduleC = 'moduleC';
+      const ns2 = namespace(moduleC);
+      @Component
+      export default class Foo {
+        @State('foo') bar: string;
+        @ns1.State('foo') baz: string;
+        @ns2.State('foo') qux: string;
+      }
+    `);
+    const result = convertAst(ast, program);
+
+    expect(result).toMatchInlineSnapshot(`
+      "import { useStore } from \\"vuex\\";
+      import { computed } from \\"vue\\";
+      const moduleC = 'moduleC';
+      const store = useStore();
+      const bar = computed<string>(() => store.state.foo);
+      const baz = computed<string>(() => store.state.moduleB.foo);
+      const qux = computed<string>(() => store.state[moduleC].foo);
+      "
+    `);
+  });
+
+  it("should transform state with variable property argument", () => {
+    const { ast, program } = getSingleFileProgram(`
+      import { Component, Vue } from 'vue-property-decorator';
+      import { State } from 'vuex-class';
+      const ns1 = namespace('moduleB');
+      const moduleC = 'moduleC';
+      const ns2 = namespace(moduleC);
+      const foo = 'foo';
+      @Component
+      export default class Foo {
+        @State(foo) bar: string;
+        @ns1.State(foo) baz: string;
+        @ns2.State(foo) qux: string;
+      }
+    `);
+    const result = convertAst(ast, program);
+
+    expect(result).toMatchInlineSnapshot(`
+      "import { useStore } from \\"vuex\\";
+      import { computed } from \\"vue\\";
+      const moduleC = 'moduleC';
+      const foo = 'foo';
+      const store = useStore();
+      const bar = computed<string>(() => store.state[foo]);
+      const baz = computed<string>(() => store.state.moduleB[foo]);
+      const qux = computed<string>(() => store.state[moduleC][foo]);
+      "
+    `);
+  });
+
+  it("should transform state with namespaced string property argument", () => {
     const { ast, program } = getSingleFileProgram(`
       import { Component, Vue } from 'vue-property-decorator';
       import { State } from 'vuex-class';
@@ -38,12 +104,12 @@ describe("State decorator", () => {
       "import { useStore } from \\"vuex\\";
       import { computed } from \\"vue\\";
       const store = useStore();
-      const bar = computed<string>(() => store.state['ns/foo']);
+      const bar = computed<string>(() => store.state[\\"ns/foo\\"]);
       "
     `);
   });
 
-  it("should transform state with namespace and variable", () => {
+  it("should transform state with namespaces string property argument concatenated with variable", () => {
     const { ast, program } = getSingleFileProgram(`
       import { Component, Vue } from 'vue-property-decorator';
       import { State } from 'vuex-class';
@@ -65,13 +131,18 @@ describe("State decorator", () => {
     `);
   });
 
-  it("should transform state with callback as decorator arg", () => {
+  it("should transform state with callback as decorator argument", () => {
     const { ast, program } = getSingleFileProgram(`
       import { Component, Vue } from 'vue-property-decorator';
-      import { State } from 'vuex-class';
+      import { State, namespace } from 'vuex-class';
+      const ns1 = namespace('moduleB');
+      const moduleC = 'moduleC';
+      const ns2 = namespace(moduleC);
       @Component
       export default class Foo {
         @State(s => s.foo.bar) bar: string;
+        @ns1.State(s => s.foo.bar) baz: string;
+        @ns2.State(s => s.foo.bar) qux: string;
       }
     `);
 
@@ -79,8 +150,11 @@ describe("State decorator", () => {
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
       import { computed } from \\"vue\\";
+      const moduleC = 'moduleC';
       const store = useStore();
       const bar = computed<string>(() => store.state.foo.bar);
+      const baz = computed<string>(() => store.state.moduleB.foo.bar);
+      const qux = computed<string>(() => store.state[moduleC].foo.bar);
       "
     `);
   });
@@ -92,6 +166,21 @@ describe("State decorator", () => {
       @Component
       export default class Foo {
         @State @State foo: string;
+      }
+    `);
+    expect(() => convertAst(ast, program)).toThrowError(
+      "[vuex-class] Duplicate @State decorators for foo",
+    );
+  });
+
+  it("should throw when there are duplicate namespaced decorators", () => {
+    const { ast, program } = getSingleFileProgram(`
+      import { Component, Vue } from 'vue-property-decorator';
+      import { State, namespace } from 'vuex-class';
+      const ns = namespace('moduleB');
+      @Component
+      export default class Foo {
+        @ns.State @ns.State foo: string;
       }
     `);
     expect(() => convertAst(ast, program)).toThrowError(

--- a/client/src/transformer/transforms/vuex-class/utils/convertVuexComputedFactory.ts
+++ b/client/src/transformer/transforms/vuex-class/utils/convertVuexComputedFactory.ts
@@ -1,12 +1,7 @@
 import { copySyntheticComments } from "@/helpers/comments";
-import {
-  createConstStatement,
-  createIdentifier,
-  getDecorators,
-  isArrowFunc,
-} from "@/helpers/tsHelpers";
+import { createConstStatement, createIdentifier, getDecorators } from "@/helpers/tsHelpers";
 import { namedImports } from "@/helpers/utils";
-import { registerDecorator } from "@/registry";
+import { getVuexNamespace, registerDecorator } from "@/registry";
 import {
   VxReferenceKind,
   VxResultKind,
@@ -14,18 +9,21 @@ import {
   VxTransform,
   VxTransformResult,
 } from "@/types";
-import { cloneNode } from "ts-clone-node";
 import ts, { isCallExpression } from "typescript";
 import { instanceDependencies } from "../../utils/instancePropertyAccess";
-import { isValidIdentifier } from "../../utils/isValidIdentifier";
+
+export type AccessExpressionGetter = (
+  property: string | ts.Expression,
+  namespace?: ts.Identifier | ts.StringLiteral,
+) => ts.ElementAccessExpression | ts.PropertyAccessExpression;
 
 export function convertVuexComputedFactory(
   decoratorName: "State" | "Getter",
-  storeProperty: "state" | "getters",
+  getAccessExpression: AccessExpressionGetter,
 ): VxTransform<ts.PropertyDeclaration> {
   return (node) => {
     const decorators = getDecorators(node, decoratorName);
-    const computedName = node.name.getText();
+    const computedName = (node.name as ts.Identifier).text;
 
     if (!decorators || decorators.length <= 0) return { shouldContinue: true };
     if (decorators.length > 1)
@@ -35,8 +33,25 @@ export function convertVuexComputedFactory(
 
     const decorator = decorators[0];
     let decoratorArgs: ts.Expression | undefined;
-    if (isCallExpression(decorator.expression)) {
-      decoratorArgs = decorator.expression.arguments[0];
+    let propExpr: ts.PropertyAccessExpression | undefined;
+    const decoratorExpr = decorator.expression;
+
+    if (isCallExpression(decoratorExpr)) {
+      decoratorArgs = decoratorExpr.arguments[0];
+
+      if (ts.isPropertyAccessExpression(decoratorExpr.expression)) {
+        propExpr = decoratorExpr.expression;
+      }
+    } else if (ts.isPropertyAccessExpression(decoratorExpr)) {
+      propExpr = decoratorExpr;
+    }
+
+    let namespace: ts.Identifier | ts.StringLiteral | undefined;
+    if (
+      propExpr &&
+      (ts.isIdentifier(propExpr.expression) || ts.isStringLiteral(propExpr.expression))
+    ) {
+      namespace = getVuexNamespace(propExpr.expression.text);
     }
 
     const typeArgs = node.type ? [node.type] : [];
@@ -44,7 +59,7 @@ export function convertVuexComputedFactory(
 
     const path = decoratorArgs ?? computedName;
 
-    const accessExpr = getAccessExpression(path, storeProperty);
+    const accessExpr = getAccessExpression(path, namespace);
     arrowFunction = createSimpleArrowFunction(accessExpr);
 
     const computedCallExpr = ts.factory.createCallExpression(
@@ -75,76 +90,10 @@ export function convertVuexComputedFactory(
   };
 }
 
-/**
- * Converts the decorator id to an arrow function with an access expression
- * @param property
- *
- * @example
- * \@State("foo") bar: string; -> (): string => store.state.foo
- * \@Getter("ns/foo") bar: boolean; -> (): boolean => store.getters["ns/foo"]
- */
-function getAccessExpression(property: string | ts.Expression, storeProperty: "state" | "getters") {
-  // @State(s => s.foo.bar) bar: string; -> store.state.foo.bar
-  if (isArrowFunc(property) && storeProperty === "state") {
-    const transformer = getArrowFnTransformer(property, storeProperty);
-    const transformedArrowFn = ts.transform(property, [transformer]).transformed[0];
-    const accessExpr = cloneNode(transformedArrowFn.body) as ts.PropertyAccessExpression;
-    return accessExpr;
-  } else if (isArrowFunc(property) && storeProperty === "getters") {
-    throw new Error("[vuex-class] Arrow functions are not supported for @Getter");
-  }
-
-  const storeId = createIdentifier("store");
-  const storePropertyId = createIdentifier(storeProperty);
-  const accessExpr = ts.factory.createPropertyAccessExpression(storeId, storePropertyId);
-
-  if (typeof property === "string") {
-    if (!isValidIdentifier(property)) {
-      // @State('ns/foo') bar: string; -> store.state['ns/foo']
-      const propertyId = ts.factory.createStringLiteral(property);
-      return ts.factory.createElementAccessExpression(accessExpr, propertyId);
-    }
-
-    // @State('foo') bar: string; -> store.state.foo
-    const propertyId = createIdentifier(property);
-    return ts.factory.createPropertyAccessExpression(accessExpr, propertyId);
-  }
-
-  // @Getter(someVar) foo: string; -> store.getters[someVar]
-  return ts.factory.createElementAccessExpression(accessExpr, property);
-}
+export type VuexPropertyTypeBase = string | ts.Identifier | ts.StringLiteral | ts.BinaryExpression;
 
 function createSimpleArrowFunction(returnValueExpr: ts.Expression) {
   const u = undefined;
   const arrowFunction = ts.factory.createArrowFunction(u, u, [], u, u, returnValueExpr);
   return arrowFunction;
-}
-
-/**
- * Takes an arrow function, visits each node of the PropertyAccessExpression
- * until it files the arrow function parameter identifier and replaces it with
- * the store.<propertyName>
- *
- * TODO this currently only supports a concise body, I don't wanna deal with more complex bodies
- *
- * @example
- * (s) => s.foo.bar; // -> store.state.foo.bar
- */
-function getArrowFnTransformer(arrowFn: ts.ArrowFunction, propertyName: "state" | "getters") {
-  const [param] = arrowFn.parameters;
-  if (!param) throw new Error("Expected an arrow function with a single parameter");
-  const propertyId = createIdentifier(propertyName);
-  const storeId = createIdentifier("store");
-  const storeStateAccess = ts.factory.createPropertyAccessExpression(storeId, propertyId);
-
-  return ((ctx) => {
-    const visitor = (node: ts.Node): ts.Node => {
-      if (ts.isIdentifier(node) && node.getText() === param.name.getText()) {
-        return storeStateAccess;
-      }
-      return ts.visitEachChild(node, visitor, ctx);
-    };
-
-    return (node) => ts.visitNode(arrowFn, visitor);
-  }) as ts.TransformerFactory<ts.ArrowFunction>;
 }

--- a/client/src/transformer/transforms/vuex-class/utils/isValidVuexDecoratorArg.ts
+++ b/client/src/transformer/transforms/vuex-class/utils/isValidVuexDecoratorArg.ts
@@ -1,0 +1,21 @@
+import ts from "typescript";
+import { VuexPropertyTypeBase } from "./vuexClass.types";
+
+export function isValidVuexNsKey(
+  expr: ts.Node | undefined,
+): expr is ts.StringLiteral | ts.Identifier {
+  return !!expr && (ts.isIdentifier(expr) || ts.isStringLiteral(expr));
+}
+
+export function isValidVuexDecoratorArg(
+  arg: ts.Node | string | undefined,
+): arg is VuexPropertyTypeBase {
+  return (
+    typeof arg !== "undefined" &&
+    (typeof arg === "string" ||
+      ts.isStringLiteral(arg) ||
+      ts.isIdentifier(arg) ||
+      ts.isPropertyAccessExpression(arg) ||
+      ts.isBinaryExpression(arg))
+  );
+}

--- a/client/src/transformer/transforms/vuex-class/utils/namespacedStoreKey.ts
+++ b/client/src/transformer/transforms/vuex-class/utils/namespacedStoreKey.ts
@@ -1,0 +1,37 @@
+import ts from "typescript";
+
+export function namespacedStoreKey(
+  namespace: ts.Identifier | ts.StringLiteral,
+  property: ts.Identifier | ts.StringLiteral,
+) {
+  if (ts.isStringLiteral(namespace) && ts.isStringLiteral(property)) {
+    // -> "moduleB/foo"
+    return ts.factory.createStringLiteral(namespace.text + "/" + property.text);
+  }
+
+  if (ts.isStringLiteral(namespace) && ts.isIdentifier(property)) {
+    // -> `moduleB/${foo}`
+    const templateHead = ts.factory.createTemplateHead(namespace.text + "/");
+    const templateSpan = ts.factory.createTemplateSpan(property, ts.factory.createTemplateTail(""));
+    return ts.factory.createTemplateExpression(templateHead, [templateSpan]);
+  }
+
+  if (ts.isIdentifier(namespace) && ts.isIdentifier(property)) {
+    // -> `${moduleB}/${foo}`
+    const templateHead = ts.factory.createTemplateHead("");
+    const namespaceSpan = ts.factory.createTemplateSpan(
+      namespace,
+      ts.factory.createTemplateMiddle("/"),
+    );
+    const templateSpan = ts.factory.createTemplateSpan(property, ts.factory.createTemplateTail(""));
+    return ts.factory.createTemplateExpression(templateHead, [namespaceSpan, templateSpan]);
+  }
+
+  // -> `${moduleB}/foo`
+  const templateHeaded = ts.factory.createTemplateHead("");
+  const namespaceSpan = ts.factory.createTemplateSpan(
+    namespace,
+    ts.factory.createTemplateTail(`/${property.text}`),
+  );
+  return ts.factory.createTemplateExpression(templateHeaded, [namespaceSpan]);
+}

--- a/client/src/transformer/transforms/vuex-class/utils/vuexClass.types.ts
+++ b/client/src/transformer/transforms/vuex-class/utils/vuexClass.types.ts
@@ -1,0 +1,45 @@
+import ts from "typescript";
+
+/**
+ * - `string` indicates that the class property name is being used as the store property name
+ * ```ts
+ *    ⁣@Getter() foo: boolean; // string : 'foo'
+ * ```
+ * - `Identifier` indicates that a variable has been passed as a parameter to the decorator
+ * ```ts
+ *    ⁣@Getter(bar) foo: boolean; // Identifier : bar
+ * ```
+ * - `StringLiteral` indicates that a string has been passed as a parameter to the decorator
+ * ```ts
+ *    ⁣@Getter('bar') foo: boolean; // StringLiteral : 'bar'
+ * ```
+ * - `BinaryExpression` indicates that a string concatenation has been passed as a parameter to the decorator
+ * ```ts
+ *    ⁣@Getter('foo/' + bar) foo: boolean; // BinaryExpression : 'foo/' + bar
+ * ```
+ */
+export type VuexPropertyTypeBase = string | ts.Identifier | ts.StringLiteral | ts.BinaryExpression;
+
+/**
+ * - `string` indicates that the class property name is being used as the store property name
+ * ```ts
+ *    ⁣@State() foo: boolean; // string : 'foo'
+ * ```
+ * - `Identifier` indicates that a variable has been passed as a parameter to the decorator
+ * ```ts
+ *    ⁣@State(bar) foo: boolean; // Identifier : bar
+ * ```
+ * - `StringLiteral` indicates that a string has been passed as a parameter to the decorator
+ * ```ts
+ *    ⁣@State('bar') foo: boolean; // StringLiteral : 'bar'
+ * ```
+ * - `BinaryExpression` indicates that a string concatenation has been passed as a parameter to the decorator
+ * ```ts
+ *    ⁣@State('foo/' + bar) foo: boolean; // BinaryExpression : 'foo/' + bar
+ * ```
+ * - `ArrowFunction` indicates that an arrow function has been passed as a parameter to the decorator
+ * ```ts
+ *    ⁣@State(s => s.foo.bar) foo: boolean; // ArrowFunction : s => s.foo.bar
+ * ```
+ */
+export type VuexStatePropertyType = VuexPropertyTypeBase | ts.ArrowFunction;


### PR DESCRIPTION
Refactors app to detect `namespace` in script body, registers the decorator variable and the associated namespace string or variable

```ts
const Ns = namespace('foo');
            │           └──── store namespace key
            └──────────────── decorator 
```

When encountering the decorator `@Ns.<State|Action|Getter|Mutation>` it will then convert the property declaration and inject the namespace into the transformed code

example

```ts
@Ns.State('baz') bar: string;

// ->

const bar = computed<string>(() => store.state.foo.baz);
```