### PR TITLE
Add support for making composables functions from VCC Mixins

### DIFF
--- a/.changeset/empty-wombats-perform.md
+++ b/.changeset/empty-wombats-perform.md
@@ -1,0 +1,5 @@
+---
+"@heatsrc/vuedc": minor
+---
+
+Try to create composables when provided a .ts file

--- a/.changeset/kind-seahorses-applaud.md
+++ b/.changeset/kind-seahorses-applaud.md
@@ -1,0 +1,6 @@
+---
+"@heatsrc/vue-declassified": patch
+"@heatsrc/vuedc": patch
+---
+
+add docs

--- a/.changeset/proud-trees-give.md
+++ b/.changeset/proud-trees-give.md
@@ -1,0 +1,5 @@
+---
+"@heatsrc/vue-declassified": minor
+---
+
+Add support for creating Composable analogues of VCC Mixins found in provided TypeScript file

--- a/cli/README.md
+++ b/cli/README.md
@@ -24,9 +24,25 @@ yarn global add @heatsrc/vuedc
 
 ## Usage
 
+### Converting a Vue Class Component to Script API
+
 ```bash
 vuedc -i MyComponent.vue -o MyOutput.vue
 ```
+
+When provided a Vue file Vuedc will convert a Vue Class Component to Script API and update the script body. Current Vuedc does not make changes in the template but does best effort to name variables the same as they were in the class to avoid needing to update. There are a few cases where this may fail, mainly when using `$ref`s with the same name as properties or accessors on the class, Vuedc will attempt to warn in the results.
+
+### Making Composable functions out of Vue Class Component Mixins
+
+```bash
+vuedc -i MyMixin.ts -y
+```
+
+When provided a `.ts` file Vuedc will make composable function analogues of any Vue Class Component Mixins found in the file and append them to the file.
+
+_Note_: Vuedc also leaves the Mixin in place as it is not certain the mixin may be used by other class based components.
+
+### `@heatsrc/vuedc --help`
 
 ```bash
 $ vuedc -h

--- a/cli/src/vuedc.ts
+++ b/cli/src/vuedc.ts
@@ -1,9 +1,10 @@
 #! /usr/bin/env node
-import { VuedcError, VuedcOptions, convertSfc } from "@heatsrc/vue-declassified";
+import { VuedcError, VuedcOptions, convertMixin, convertSfc } from "@heatsrc/vue-declassified";
 import chalk from "chalk";
 import { Command } from "commander";
 import figlet from "figlet";
 import { readFile, writeFile } from "node:fs/promises";
+import { extname } from "node:path";
 import Readline from "node:readline/promises";
 import pkg from "../package.json";
 
@@ -68,7 +69,15 @@ async function main() {
   try {
     const content = await readFile(options.input, { encoding: "utf8" });
     const opts: VuedcOptions = { stopOnCollisions: !options.ignoreCollisions, basePath };
-    const result = await convertSfc(content, opts);
+
+    let result: string;
+    if (extname(options.input) === ".vue") {
+      console.log("Detected Vue file, converting to script setup");
+      result = await convertSfc(content, opts);
+    } else {
+      console.log("Detected TypeScript file, converting mixin(s) to composable");
+      result = await convertMixin(content, opts);
+    }
 
     await writeFile(output, result, { encoding: "utf8" });
 

--- a/client/README.md
+++ b/client/README.md
@@ -32,7 +32,7 @@
     - [`$refs` with same name as class members](#refs-with-same-name-as-class-members)
     - [Top level identifiers](#top-level-identifiers)
     - [Reactive Variables](#reactive-variables)
-    - [Mixins](#mixins)
+    - [Transforming Components extending Mixins](#transforming-components-extending-mixins)
 
 ## Vue Class Components -> Vue 3 script setup
 
@@ -51,7 +51,8 @@ These decisions are made arbitrarily, mostly for sanity and convenience. You get
 - Will reference macros by arbitrary variables (see below)
 - Will be formatted by prettier with default config
   - exception `printWidth` increased to 100 characters
-- Mixins will be renamed to match composable conventions (see [Tips/Gotchas: Mixins](#mixins))
+- Mixins will be renamed to match composable conventions (see [Tips/Gotchas: Mixins](#transforming-components-extending-mixins))
+- When transforming TypeScript files containing mixins a new composable will be appended to the file but the existing mixin will be left
 
 ## Usage
 
@@ -367,7 +368,7 @@ These are options provided in the decorator call, e.g., `@Component({ components
 ### Misc features
 
 <details>
-<summary>Other features (6/6 :rocket:)</summary>
+<summary>Other features (7/7 :rocket:)</summary>
 
 - :white_check_mark: **Limited type inference**
   - If a node is untyped, will do a best guess at type (mostly primitive types only).
@@ -385,6 +386,8 @@ These are options provided in the decorator call, e.g., `@Component({ components
 - :white_check_mark: **Composable definitions**
   - When former "builtin" globals such as `$store`/`$router`/etc are found vuedc will automatically import and assign to a variable
   - e.g., `const store = useStore()`
+- :white_check_mark: **Transforming Mixin**
+  - Typescript files can be provided to `convertMixin` and any mixin found in that file will have a composable analogue created and appended to the file.
 
 </details>
 
@@ -524,7 +527,7 @@ When Vuedc encounters a data property assigned to an Array or Object it will ass
 
 You can convert the `reactive` to `ref` and add `.value` to the reassignments but you will lose deep reactivity of those variables (which may be the intention.)
 
-#### Mixins
+#### Transforming Components extending Mixins
 
 :exclamation: **Note:** Mixins support only works when you provide `convertSfc` with a `basePath` in the VuedcOptions (or with the `-p | --project` flag in the Vuedc cli tool).
 

--- a/client/README.md
+++ b/client/README.md
@@ -68,6 +68,8 @@ npm install -g @heatsrc/vuedc
 yarn add -g @heatsrc/vuedc
 
 vuedc -i myVueComponent.vue -o myVueComponent.converted.vue
+# Or create composables out of VCC Mixins
+vuedc -i myMixin.ts
 ```
 
 or run directly with hot loading
@@ -130,20 +132,29 @@ export type VuedcOptions = {
 ```
 
 ```ts
-import { convertSfc } from "@heatsrc/vue-declassified";
+import { convertSfc, convertMixin } from "@heatsrc/vue-declassified";
 import {readFile, writeFile} from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { dirname, extName } from 'node:path';
 
 const input = "./myVueComponent.vue";
 const output = "./myVueComponent.converted.vue";
 
 (async () => {
   const encoding = {encoding: 'utf8'};
+  const ext = extName(input);
   const inputFile = await readFile(input, encoding);
 
-  const result = await convertSfc(input);
-  // or with options
-  // const result = await convertSfc(input, {stopOnCollisions: true, basePath: dirname(input)});
+  const result: string | undefined;
+  if (extName === '.vue') {
+    result = await convertSfc(input);
+    // or with options
+    // result = await convertSfc(input, {stopOnCollisions: true, basePath: dirname(input)});
+  } else {
+    result = await convertMixin(input);
+    // or with options
+    // result = await convertMixin(input, {stopOnCollisions: true, basePath: dirname(input)});
+  }
+
 
   await writeFile(output, encoding);
 }());

--- a/client/src/__tests__/convert.test.ts
+++ b/client/src/__tests__/convert.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { convertAst } from "../convert.js";
+import { convertDefaultClassComponent } from "../convert.js";
 import { getSingleFileProgram } from "../parser.js";
 
 describe("convert", () => {
   it("should throw if no vue class component import", () => {
     let content = "@Component\nexport class Test {}";
     const { ast, program } = getSingleFileProgram(content);
-    expect(() => convertAst(ast, program)).toThrowError(
+    expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
       "No vue class component import found in this file",
     );
   });
@@ -20,7 +20,9 @@ describe("convert", () => {
         @Prop() hello!: string;
       }`;
       const { ast, program } = getSingleFileProgram(content);
-      expect(() => convertAst(ast, program)).toThrowError("No default export found in this file");
+      expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
+        "No default export found in this file",
+      );
     });
 
     it("should throw if default export is not a class", () => {
@@ -31,7 +33,9 @@ describe("convert", () => {
         return <div>Hello</div>
       }`;
       const { ast, program } = getSingleFileProgram(content);
-      expect(() => convertAst(ast, program)).toThrowError("No default export found in this file");
+      expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
+        "No default export found in this file",
+      );
     });
 
     it('should throw if default export is not decorated with "@Component" or "@Options"', () => {
@@ -41,7 +45,9 @@ describe("convert", () => {
         @Prop() hello!: string;
       }`;
       const { ast, program } = getSingleFileProgram(content);
-      expect(() => convertAst(ast, program)).toThrowError("No default export found in this file");
+      expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
+        "No default export found in this file",
+      );
     });
 
     it('should not throw if default export is decorated with "@Component"', () => {
@@ -52,7 +58,7 @@ describe("convert", () => {
         @Prop() hello!: string;
       }`;
       const { ast, program } = getSingleFileProgram(content);
-      expect(() => convertAst(ast, program)).not.toThrow();
+      expect(() => convertDefaultClassComponent(ast, program)).not.toThrow();
     });
 
     it('should not throw if default export is decorated with "@Options"', () => {
@@ -63,7 +69,7 @@ describe("convert", () => {
         @Prop() hello!: string;
       }`;
       const { ast, program } = getSingleFileProgram(content);
-      expect(() => convertAst(ast, program)).not.toThrow();
+      expect(() => convertDefaultClassComponent(ast, program)).not.toThrow();
     });
   });
 
@@ -221,7 +227,7 @@ describe("convert", () => {
     import foo from "foo";`;
 
     const { ast, program } = getSingleFileProgram(content);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     // XXX this snapshot is a WIP, it's not the final result
     expect(result).toMatchInlineSnapshot(`

--- a/client/src/__tests__/main.test.ts
+++ b/client/src/__tests__/main.test.ts
@@ -217,6 +217,7 @@ export class Foo {
       const result = await convertMixin(mixinString);
       expect(result).toMatchInlineSnapshot(`
         "import { Component, Emit } from \\"vue-property-decorator\\";
+        import { ref } from \\"vue\\";
         @Component
         export class Foo {
           foo = \\"hello world\\";

--- a/client/src/__tests__/main.test.ts
+++ b/client/src/__tests__/main.test.ts
@@ -1,11 +1,12 @@
-import { convertScript, convertSfc } from "@/main";
+import { convertMixin, convertScript, convertSfc } from "@/main";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 describe("main test", () => {
-  it("should convert a Vue SFC file containing Vue Class Component to Script Setup syntax", async () => {
-    const sfcString = `
+  describe("convertSfc", () => {
+    it("should convert a Vue SFC file containing Vue Class Component to Script Setup syntax", async () => {
+      const sfcString = `
 <template><div>{{ foo }}</div></template>
 <script lang="ts">
 import { Component, Emit } from 'vue-property-decorator';
@@ -20,9 +21,9 @@ div {
 }
 </style>
     `;
-    const result = await convertSfc(sfcString);
+      const result = await convertSfc(sfcString);
 
-    expect(result).toMatchInlineSnapshot(`
+      expect(result).toMatchInlineSnapshot(`
       "<script setup lang=\\"ts\\">
       import { ref } from \\"vue\\";
       const foo = ref(\\"hello world\\");
@@ -37,10 +38,10 @@ div {
       }
       </style>"
     `);
-  });
+    });
 
-  it("should reject trying to parse an invalid vue file", async () => {
-    const sfcString = `
+    it("should reject trying to parse an invalid vue file", async () => {
+      const sfcString = `
       <template></template><!-- oops unexpected closing tag --></template>
       <script lang="ts">
       import { Component, Emit } from 'vue-property-decorator';
@@ -52,23 +53,23 @@ div {
       <style></style>
     `;
 
-    await expect(() => convertSfc(sfcString)).rejects.toThrow("Vue file has errors");
-    expect.assertions(1);
-  });
+      await expect(() => convertSfc(sfcString)).rejects.toThrow("Vue file has errors");
+      expect.assertions(1);
+    });
 
-  it("should reject is missing script body", async () => {
-    const sfcString = `
+    it("should reject is missing script body", async () => {
+      const sfcString = `
       <template></template>
       <script lang="ts"></script>
       <style></style>
     `;
 
-    await expect(() => convertSfc(sfcString)).rejects.toThrow("Vue file has no script!");
-    expect.assertions(1);
-  });
+      await expect(() => convertSfc(sfcString)).rejects.toThrow("Vue file has no script!");
+      expect.assertions(1);
+    });
 
-  it("should reject if missing default export", async () => {
-    const sfcString = `
+    it("should reject if missing default export", async () => {
+      const sfcString = `
       <template></template>
       <script lang="ts">
       import { Component, Emit } from 'vue-property-decorator';
@@ -80,14 +81,14 @@ div {
       <style></style>
     })`;
 
-    await expect(() => convertSfc(sfcString)).rejects.toThrow(
-      "No default export found in this file",
-    );
-    expect.assertions(1);
-  });
+      await expect(() => convertSfc(sfcString)).rejects.toThrow(
+        "No default export found in this file",
+      );
+      expect.assertions(1);
+    });
 
-  it("should reject if already script setup", async () => {
-    const sfcString = `
+    it("should reject if already script setup", async () => {
+      const sfcString = `
       <template></template>
       <script lang="ts" setup>
       import { Component, Emit } from 'vue-property-decorator';
@@ -99,21 +100,78 @@ div {
       <style></style>
     })`;
 
-    await expect(() => convertSfc(sfcString)).rejects.toThrow("Vue file already has script setup!");
-    expect.assertions(1);
-  });
+      await expect(() => convertSfc(sfcString)).rejects.toThrow(
+        "Vue file already has script setup!",
+      );
+      expect.assertions(1);
+    });
 
-  describe("naming collisions", () => {
-    it("should warn about naming collisions", async () => {
+    describe("naming collisions", () => {
+      it("should warn about naming collisions", async () => {
+        const path = resolve(__dirname, "./fixtures/NamingCollisions.vue");
+        const content = await readFile(path, { encoding: "utf8" });
+
+        const result = await convertSfc(content);
+
+        expect(result).toMatchInlineSnapshot(`
+          "<script setup lang=\\"ts\\">
+          /*
+          [VUEDC_TODO] Fix naming collisions
+           
+            - \`baz\` (TemplateRef) was already defined in: import declarations, class body
+            - \`foo\` (Data-ref) was already defined in: import declarations
+            - \`qux\` (Method) was already defined in: top level variable declarations
+            - \`quux\` (TemplateRef) was already defined in: top level variable declarations
+            - \`car\` (Inject) was already defined in: top level variable declarations
+            - \`haptic\` (VuexMethod-Action) was already defined in: top level variable declarations
+
+          It is strongly suggested you fix these prior to converting the file.
+          Usage of these variables may be ambiguous in the converted code.
+
+          Tips: https://github.com/heatsrc/vue-declassified#naming-collisions
+
+          */
+
+          import { baz } from \\"./baz\\";
+          import foo from \\"./foo\\";
+          import { computed, ref, reactive, inject } from \\"vue\\";
+          import { useStore } from \\"vuex\\";
+          const {
+            qux,
+            okay: { haptic },
+          } = { qux: \\"qux\\" };
+          const [quux, { car }] = [\\"quux\\", { car: \\"car\\" }];
+          const store = useStore();
+          const bar = computed(() => {
+            return \\"string\\";
+          });
+          /* [VUEDC_TODO]: Check for potential naming collisions from '$refs.baz' conversion.*/ const baz =
+            ref<HTMLDivElement>();
+          const foo = ref(\\"string\\");
+          const baz = reactive(baz);
+          const qux = () => {
+            return 1;
+          };
+          const quux = ref<HTMLDivElement>();
+          const car = inject<string>(\\"vehicle\\");
+          const haptic = async (): Promise<void> => store.dispatch(\\"haptic\\");
+
+          </script>
+
+          <template>
+            <div>{{ foo }}</div>
+          </template>"
+        `);
+      });
+    });
+
+    it('should stop on collisions when "stopOnCollisions" is true', async () => {
       const path = resolve(__dirname, "./fixtures/NamingCollisions.vue");
       const content = await readFile(path, { encoding: "utf8" });
 
-      const result = await convertSfc(content);
-
-      expect(result).toMatchInlineSnapshot(`
-        "<script setup lang=\\"ts\\">
-        /*
-        [VUEDC_TODO] Fix naming collisions
+      await expect(() => convertSfc(content, { stopOnCollisions: true })).rejects
+        .toThrowErrorMatchingInlineSnapshot(`
+        "Fix naming collisions
          
           - \`baz\` (TemplateRef) was already defined in: import declarations, class body
           - \`foo\` (Data-ref) was already defined in: import declarations
@@ -126,79 +184,51 @@ div {
         Usage of these variables may be ambiguous in the converted code.
 
         Tips: https://github.com/heatsrc/vue-declassified#naming-collisions
-
-        */
-
-        import { baz } from \\"./baz\\";
-        import foo from \\"./foo\\";
-        import { computed, ref, reactive, inject } from \\"vue\\";
-        import { useStore } from \\"vuex\\";
-        const {
-          qux,
-          okay: { haptic },
-        } = { qux: \\"qux\\" };
-        const [quux, { car }] = [\\"quux\\", { car: \\"car\\" }];
-        const store = useStore();
-        const bar = computed(() => {
-          return \\"string\\";
-        });
-        /* [VUEDC_TODO]: Check for potential naming collisions from '$refs.baz' conversion.*/ const baz =
-          ref<HTMLDivElement>();
-        const foo = ref(\\"string\\");
-        const baz = reactive(baz);
-        const qux = () => {
-          return 1;
-        };
-        const quux = ref<HTMLDivElement>();
-        const car = inject<string>(\\"vehicle\\");
-        const haptic = async (): Promise<void> => store.dispatch(\\"haptic\\");
-
-        </script>
-
-        <template>
-          <div>{{ foo }}</div>
-        </template>"
+        "
       `);
     });
-  });
 
-  it('should stop on collisions when "stopOnCollisions" is true', async () => {
-    const path = resolve(__dirname, "./fixtures/NamingCollisions.vue");
-    const content = await readFile(path, { encoding: "utf8" });
-
-    await expect(() => convertSfc(content, { stopOnCollisions: true })).rejects
-      .toThrowErrorMatchingInlineSnapshot(`
-      "Fix naming collisions
-       
-        - \`baz\` (TemplateRef) was already defined in: import declarations, class body
-        - \`foo\` (Data-ref) was already defined in: import declarations
-        - \`qux\` (Method) was already defined in: top level variable declarations
-        - \`quux\` (TemplateRef) was already defined in: top level variable declarations
-        - \`car\` (Inject) was already defined in: top level variable declarations
-        - \`haptic\` (VuexMethod-Action) was already defined in: top level variable declarations
-
-      It is strongly suggested you fix these prior to converting the file.
-      Usage of these variables may be ambiguous in the converted code.
-
-      Tips: https://github.com/heatsrc/vue-declassified#naming-collisions
-      "
-    `);
-  });
-
-  it("should convert convert just a script body", async () => {
-    const scriptString = `
+    it("should convert convert just a script body", async () => {
+      const scriptString = `
 import { Component, Emit } from 'vue-property-decorator';
 @Component
 export default class Foo {
   foo = 'hello world';
 }
     `;
-    const result = await convertScript(scriptString);
+      const result = await convertScript(scriptString);
 
-    expect(result).toMatchInlineSnapshot(`
+      expect(result).toMatchInlineSnapshot(`
       "import { ref } from \\"vue\\";
       const foo = ref(\\"hello world\\");
       "
     `);
+    });
+  });
+
+  describe("convertMixin", () => {
+    it("should convert a mixin to a composable", async () => {
+      const mixinString = `
+import { Component, Emit } from 'vue-property-decorator';
+@Component
+export class Foo {
+  foo = 'hello world';
+}`;
+      const result = await convertMixin(mixinString);
+      expect(result).toMatchInlineSnapshot(`
+        "import { Component, Emit } from \\"vue-property-decorator\\";
+        @Component
+        export class Foo {
+          foo = \\"hello world\\";
+        }
+
+        export function useFoo() {
+          const foo = ref(\\"hello world\\");
+
+          return { foo };
+        }
+        "
+      `);
+    });
   });
 });

--- a/client/src/convert.ts
+++ b/client/src/convert.ts
@@ -1,51 +1,30 @@
-import Debug from "debug";
+import getDebug from "debug";
 import ts from "typescript";
-import { registerTopLevelVars } from "./helpers/collisionDetection.js";
-import { getDecoratorNames, getPackageName } from "./helpers/tsHelpers.js";
 import {
-  getImportNameOverride,
-  registerDecorator,
-  setImportNameOverride,
-  setVuexNamespace,
-} from "./registry.js";
-import { runTransforms } from "./transformer.js";
+  filterUnwantedPreamble,
+  getClassComponents,
+  getDefaultExportNode,
+  getPreamble,
+  hasVccImports,
+  registerImportNameOverrides,
+} from "./convert/convertHelpers.js";
+import { registerVuexNamespaces } from "./convert/vuexClassHelpers.js";
+import { registerTopLevelVars } from "./helpers/collisionDetection.js";
+import { organizeSfcScript, runTransforms } from "./transformer.js";
 
-const debug = Debug("vuedc:convert");
-const vccPackages = ["vue-class-component", "vue-property-decorator", "vuex-class"];
+const debug = getDebug("vuedc:convert");
 
 export function convertDefaultClassComponent(source: ts.SourceFile, program: ts.Program) {
   if (!hasVccImports(source)) throw new Error("No vue class component import found in this file");
 
-  const defaultExportNode = getDefaultExportNode(source);
-  if (!defaultExportNode) throw new Error("No default export found in this file");
+  const defaultExport = getDefaultExportNode(source);
+  if (!defaultExport) throw new Error("No default export found in this file");
 
-  const outsideStatements = getOutsideStatements(source);
-  registerTopLevelVars(outsideStatements);
-  registerImportNameOverrides(outsideStatements);
-  registerVuexNamespaces(outsideStatements);
+  const preamble = handlePreamble(source);
+  const results = runTransforms(defaultExport, program);
+  const organizedScriptBody = organizeSfcScript(defaultExport, results, preamble);
+  const result = updateSource(source, organizedScriptBody);
 
-  const unwantedStatements = (s: ts.Statement) => {
-    const pkg = getPackageName(s);
-    if (pkg && vccPackages.includes(pkg)) return true;
-    if (pkg === "vue") return true;
-    if (getNamespaceStatement(s)) return true;
-  };
-  debug("Removing unwanted imports");
-  const filteredOutsideStatements = outsideStatements.filter((s) => !unwantedStatements(s));
-
-  debug("Running transforms");
-  let resultStatements = runTransforms(defaultExportNode, filteredOutsideStatements, program);
-
-  // Group imports at start
-  resultStatements = [
-    ...resultStatements.filter((s) => ts.isImportDeclaration(s)),
-    ...resultStatements.filter((s) => !ts.isImportDeclaration(s)),
-  ];
-
-  debug("Updating source file");
-  const printer = ts.createPrinter();
-  const newSourceFile = ts.factory.updateSourceFile(source, resultStatements);
-  const result = printer.printFile(newSourceFile);
   return result;
 }
 
@@ -55,101 +34,36 @@ export function convertMixinClassComponents(source: ts.SourceFile, program: ts.P
   const classes = getClassComponents(source);
   if (!classes) throw new Error("No vue class components found in this file");
 
-  const outsideStatements = getOutsideStatements(source);
-  registerTopLevelVars(outsideStatements);
-  registerImportNameOverrides(outsideStatements);
-  registerVuexNamespaces(outsideStatements);
+  const preamble = handlePreamble(source);
 
-  debug("Running transforms");
-  let resultStatements = runTransforms(null, outsideStatements, program);
+  const results = classes.map((cls) => {
+    debug("Running transforms");
+    let resultStatements = runTransforms(cls, program);
 
-  // Group imports at start
-  resultStatements = [
-    ...resultStatements.filter((s) => ts.isImportDeclaration(s)),
-    ...resultStatements.filter((s) => !ts.isImportDeclaration(s)),
-  ];
+    // Group imports at start
+    resultStatements = [
+      ...resultStatements.filter((s) => ts.isImportDeclaration(s)),
+      ...resultStatements.filter((s) => !ts.isImportDeclaration(s)),
+    ];
 
+    const result = updateSource(source, resultStatements);
+    return result;
+  });
+}
+
+function handlePreamble(source: ts.SourceFile) {
+  const preamble = getPreamble(source);
+  registerTopLevelVars(preamble);
+  registerImportNameOverrides(preamble);
+  registerVuexNamespaces(preamble);
+  const filteredPreamble = filterUnwantedPreamble(preamble);
+  return filteredPreamble;
+}
+
+function updateSource(source: ts.SourceFile, statements: ts.Statement[]) {
   debug("Updating source file");
   const printer = ts.createPrinter();
-  const newSourceFile = ts.factory.updateSourceFile(source, resultStatements);
+  const newSourceFile = ts.factory.updateSourceFile(source, statements);
   const result = printer.printFile(newSourceFile);
   return result;
-}
-
-function registerVuexNamespaces(statements: ts.Statement[]) {
-  statements.forEach((s) => {
-    const ns = getNamespaceStatement(s);
-    if (!ns) return;
-
-    const namespace = ns.initializer.arguments[0];
-    if (!namespace || (!ts.isStringLiteral(namespace) && !ts.isIdentifier(namespace))) return;
-    setVuexNamespace(ns.name.text, namespace);
-    registerDecorator(ns.name.text);
-  });
-}
-
-function getNamespaceStatement(statement: ts.Statement) {
-  const namespaceDecl = getImportNameOverride("namespace") ?? "namespace";
-  if (!ts.isVariableStatement(statement)) return false;
-  if (statement.declarationList.declarations.length !== 1) return false;
-  const declaration = statement.declarationList.declarations[0];
-  if (!ts.isIdentifier(declaration.name)) return false;
-  if (!declaration.initializer || !ts.isCallExpression(declaration.initializer)) return false;
-  const expr = declaration.initializer.expression;
-  if (!ts.isIdentifier(expr)) return false;
-  if (expr.text !== namespaceDecl) return false;
-  return { name: declaration.name, initializer: declaration.initializer };
-}
-
-function registerImportNameOverrides(statements: ts.Statement[]) {
-  const imports = statements.filter((s): s is ts.ImportDeclaration => ts.isImportDeclaration(s));
-  imports.forEach((imp) => {
-    const importClause = imp.importClause;
-    if (!importClause) return;
-    if (!importClause.namedBindings) return;
-    if (!ts.isNamedImports(importClause.namedBindings)) return;
-    importClause.namedBindings.elements.forEach((el) => {
-      if (!el.propertyName) return;
-      setImportNameOverride(el.propertyName.text, el.name.text);
-    });
-  });
-}
-/**
- * Get's the statements outside of the default class export
- * @param source
- * @returns statements not belonging to the default class export
- */
-function getOutsideStatements(source: ts.SourceFile) {
-  debug("Getting statements outside of default export");
-  const unwantedStatements = (s: ts.Statement) => ts.isClassDeclaration(s) && getDecoratorNames(s);
-  return source.statements.map((el) => el).filter((el) => !unwantedStatements(el));
-}
-
-function hasVccImports(source: ts.SourceFile) {
-  debug("Checking for vue class component imports");
-  return source.statements.find((s) => {
-    if (!ts.isImportDeclaration(s)) return false;
-    if (!vccPackages.includes((s.moduleSpecifier as ts.StringLiteral).text)) return false;
-    return true;
-  });
-}
-
-function getDefaultExportNode(sourceFile: ts.SourceFile) {
-  debug("Checking for default export");
-  const classes = getClassComponents(sourceFile);
-  const defaultKeywordKind = ts.SyntaxKind.DefaultKeyword;
-  const defaultExport = (c: ts.ClassDeclaration) =>
-    c.modifiers?.find((m) => m.kind === defaultKeywordKind);
-  const defExport = classes.find(defaultExport);
-
-  return defExport;
-}
-
-function getClassComponents(sourceFile: ts.SourceFile) {
-  debug("Finding all class components");
-  const classes = sourceFile.statements
-    .filter((s): s is ts.ClassDeclaration => ts.isClassDeclaration(s))
-    .filter((c) => getDecoratorNames(c)?.some((d) => /(Options|Component)/.test(d)));
-
-  return classes;
 }

--- a/client/src/convert/convertHelpers.ts
+++ b/client/src/convert/convertHelpers.ts
@@ -1,0 +1,98 @@
+import { getDecoratorNames, getPackageName } from "@/helpers/tsHelpers";
+import { setImportNameOverride } from "@/registry";
+import getDebug from "debug";
+import ts from "typescript";
+import { getNamespaceStatement } from "./vuexClassHelpers";
+
+const debug = getDebug("vuedc:convert:convertHelpers");
+const VCC_PACKAGES = ["vue-class-component", "vue-property-decorator", "vuex-class"];
+
+/**
+ * Registers import name overrides from the script block
+ * @param statements
+ */
+export function registerImportNameOverrides(statements: ts.Statement[]) {
+  const imports = statements.filter((s): s is ts.ImportDeclaration => ts.isImportDeclaration(s));
+  imports.forEach((imp) => {
+    const importClause = imp.importClause;
+    if (!importClause) return;
+    if (!importClause.namedBindings) return;
+    if (!ts.isNamedImports(importClause.namedBindings)) return;
+    importClause.namedBindings.elements.forEach((el) => {
+      if (!el.propertyName) return;
+      debug(`Setting import name override: ${el.propertyName.text} -> ${el.name.text}`);
+      setImportNameOverride(el.propertyName.text, el.name.text);
+    });
+  });
+}
+/**
+ * Gets the statements outside of the default class export
+ * @param source
+ * @returns statements not belonging to the default class export
+ */
+export function getPreamble(source: ts.SourceFile) {
+  debug("Getting statements outside of default export");
+  const unwantedStatements = (s: ts.Statement) => ts.isClassDeclaration(s) && getDecoratorNames(s);
+  return source.statements.map((el) => el).filter((el) => !unwantedStatements(el));
+}
+
+/**
+ * Checks if the source file has vue class component imports
+ * @param source
+ * @returns false if no vue class component imports found
+ */
+export function hasVccImports(source: ts.SourceFile) {
+  debug("Checking for vue class component imports");
+  return source.statements.find((s) => {
+    if (!ts.isImportDeclaration(s)) return false;
+    if (!VCC_PACKAGES.includes((s.moduleSpecifier as ts.StringLiteral).text)) return false;
+    return true;
+  });
+}
+
+/**
+ * Gets the default export node
+ * @param sourceFile
+ * @returns default export node
+ */
+export function getDefaultExportNode(sourceFile: ts.SourceFile) {
+  debug("Checking for default export");
+  const classes = getClassComponents(sourceFile);
+  const defaultKeywordKind = ts.SyntaxKind.DefaultKeyword;
+  const defaultExport = (c: ts.ClassDeclaration) =>
+    c.modifiers?.find((m) => m.kind === defaultKeywordKind);
+  const defExport = classes.find(defaultExport);
+
+  return defExport;
+}
+
+/**
+ * Gets all class components in the source file
+ * @param sourceFile
+ * @returns all class components
+ */
+export function getClassComponents(sourceFile: ts.SourceFile) {
+  debug("Finding all class components");
+  const classes = sourceFile.statements
+    .filter((s): s is ts.ClassDeclaration => ts.isClassDeclaration(s))
+    .filter((c) => getDecoratorNames(c)?.some((d) => /(Options|Component)/.test(d)));
+
+  return classes;
+}
+
+/**
+ * Filters out unwanted imports and statements from the script block
+ * @param preamble
+ * @returns filtered script block statements
+ */
+export function filterUnwantedPreamble(preamble: ts.Statement[]) {
+  const unwantedStatements = (s: ts.Statement) => {
+    const pkg = getPackageName(s);
+    if (pkg && VCC_PACKAGES.includes(pkg)) return true;
+    if (pkg === "vue") return true;
+    if (getNamespaceStatement(s)) return true;
+  };
+  debug("Removing unwanted imports and statements (e.g., vuex-class namespace)");
+  const filteredPreamble = preamble.filter((s) => !unwantedStatements(s));
+  return filteredPreamble;
+}

--- a/client/src/convert/vuexClassHelpers.ts
+++ b/client/src/convert/vuexClassHelpers.ts
@@ -1,0 +1,43 @@
+import { getImportNameOverride, registerDecorator, setVuexNamespace } from "@/registry";
+import getDebug from "debug";
+import ts from "typescript";
+
+const debug = getDebug("vuedc:convert:vuexClassHelpers");
+
+/**
+ * Checks vuex-class namespace statement from registered the import name,
+ * decorator name, and namespace name
+ * @param statements
+ */
+export function registerVuexNamespaces(statements: ts.Statement[]) {
+  statements.forEach((s) => {
+    const ns = getNamespaceStatement(s);
+    if (!ns) return;
+
+    const namespace = ns.initializer.arguments[0];
+    if (!namespace || (!ts.isStringLiteral(namespace) && !ts.isIdentifier(namespace))) return;
+    debug(`Setting vuex namespace for @${getImportNameOverride("namespace")}: ${namespace.text}`);
+    setVuexNamespace(ns.name.text, namespace);
+    registerDecorator(ns.name.text);
+  });
+}
+
+/**
+ * Finds the namespace statement in the script block and returns the variable
+ * name and initializer
+ * @param statement
+ * @returns
+ */
+export function getNamespaceStatement(statement: ts.Statement) {
+  const namespaceDecl = getImportNameOverride("namespace");
+  if (!ts.isVariableStatement(statement)) return false;
+  if (statement.declarationList.declarations.length !== 1) return false;
+  const declaration = statement.declarationList.declarations[0];
+  if (!ts.isIdentifier(declaration.name)) return false;
+  if (!declaration.initializer || !ts.isCallExpression(declaration.initializer)) return false;
+  const expr = declaration.initializer.expression;
+  if (!ts.isIdentifier(expr)) return false;
+  if (expr.text !== namespaceDecl) return false;
+  debug(`Found vuex namespace statement: ${declaration.name.text}`);
+  return { name: declaration.name, initializer: declaration.initializer };
+}

--- a/client/src/helpers/tsHelpers.ts
+++ b/client/src/helpers/tsHelpers.ts
@@ -252,3 +252,13 @@ export function isIdent(node: ts.Node | unknown): node is ts.Identifier {
 export function isArrowFunc(node: ts.Node | unknown): node is ts.ArrowFunction {
   return isTypeOfNode<ts.ArrowFunction>(node, "isArrowFunction");
 }
+
+/**
+ * This is a workaround for the TS compiler not having a good way to create a
+ * newline
+ * @returns new line identifier disguised as a statement
+ */
+export function newLineNode() {
+  // converting this to a "statement" so ts won't complain
+  return factory.createIdentifier("\n") as unknown as ts.Statement;
+}

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -3,7 +3,7 @@ import * as prettier from "prettier";
 import * as parserTypescript from "prettier/parser-typescript";
 import * as parserEsTree from "prettier/plugins/estree.js";
 import ts from "typescript";
-import { convertAst } from "./convert.js";
+import { convertDefaultClassComponent } from "./convert.js";
 import { readVueFile, writeVueFile } from "./file.js";
 import { getCollisionsWarning } from "./helpers/collisionDetection.js";
 import { getSingleFileProgram } from "./parser.js";
@@ -54,7 +54,17 @@ export async function convertSfc(src: string, opts: Partial<VuedcOptions> = {}) 
 }
 
 /**
- * Accepts a Vue SFC Script body in string format and returns the converted Script Setup syntax
+ * Takes a TypeScript file creates a composable analogue of any mixins found in
+ * the file
+ *
+ * @param src
+ * @param opts
+ */
+export async function convertMixin(src: string, opts: Partial<VuedcOptions> = {}) {}
+
+/**
+ * Accepts a Vue SFC Script body in string format and returns the converted
+ * Script Setup syntax
  * @param src A single file containing a Vue Class Component
  * @returns Converted Script Setup syntax
  */
@@ -67,7 +77,7 @@ export async function convertScript(src: string, opts: Partial<VuedcOptions> = {
     if (configFile) tsConfigPath = configFile;
   }
   const { ast, program } = getSingleFileProgram(src, opts.basePath, tsConfigPath);
-  const result = convertAst(ast, program);
+  const result = convertDefaultClassComponent(ast, program);
 
   if (opts.stopOnCollisions && hasCollisions()) {
     throw new VuedcError(getCollisionsWarning(false));

--- a/client/src/registry.ts
+++ b/client/src/registry.ts
@@ -1,6 +1,6 @@
-import Debug from "debug";
+import getDebug from "debug";
 import ts from "typescript";
-const debug = Debug("vuedc:registry");
+const debug = getDebug("vuedc:registry");
 /**
  * Global registry singleton for file level metadata that can be useful
  */
@@ -15,6 +15,7 @@ class Registry {
   importNameOverrides = new Map<string, string>();
   warnings = new Set<string>();
   vuexNamespacedDecorators = new Map<string, ts.StringLiteral | ts.Identifier>();
+  isMixin = false;
 }
 const registry = new Registry();
 
@@ -28,6 +29,7 @@ export function resetRegistry() {
   registry.collisions.clear();
   registry.warnings.clear();
   registry.vuexNamespacedDecorators.clear();
+  registry.isMixin = false;
 }
 
 export function isDecoratorRegistered(decorator: string) {
@@ -120,4 +122,13 @@ export function setVuexNamespace(decorator: string, namespace: ts.StringLiteral 
 export function getVuexNamespace(decorator: string) {
   debug(`Getting vuex namespace for @${decorator}`);
   return registry.vuexNamespacedDecorators.get(decorator);
+}
+
+export function setIsMixin() {
+  debug(`Setting isMixin flag to true`);
+  registry.isMixin = true;
+}
+
+export function isMixin() {
+  return registry.isMixin;
 }

--- a/client/src/registry.ts
+++ b/client/src/registry.ts
@@ -100,7 +100,7 @@ export function hasImportNameOverride(importName: string) {
 
 export function getImportNameOverride(importName: string) {
   debug(`Getting import name override: ${importName}`);
-  return registry.importNameOverrides.get(importName);
+  return registry.importNameOverrides.get(importName) ?? importName;
 }
 
 export function addGlobalWarning(message: string) {

--- a/client/src/transformer/config.ts
+++ b/client/src/transformer/config.ts
@@ -3,6 +3,7 @@ import ts from "typescript";
 import { mergeComposables } from "./transforms/mergeComposables.js";
 import { mergeMacros } from "./transforms/mergeMacros.js";
 import { processPropertyAccessAndSort } from "./transforms/processPropertyAccessAndSort.js";
+import { transformVccToComposable } from "./transforms/transformVccToComposable.js";
 import {
   mergeComputed,
   transformGetter,
@@ -79,5 +80,11 @@ export const classTransforms: VxClassTransforms = {
     transformMethod,
   ],
   /** Post processing transforms */
-  after: [mergeMacros, mergeComposables, mergeComputed, processPropertyAccessAndSort],
+  after: [
+    mergeMacros,
+    mergeComposables,
+    mergeComputed,
+    processPropertyAccessAndSort,
+    transformVccToComposable,
+  ],
 };

--- a/client/src/transformer/resultsProcessor.ts
+++ b/client/src/transformer/resultsProcessor.ts
@@ -70,3 +70,10 @@ export function getComposables(results: VxTransformResult<ts.Node>[]) {
   debug("Collating Composables");
   return results.filter(isComposableType).flatMap((el) => el.nodes);
 }
+
+export function getUsedDefinables(results: VxTransformResult<ts.Node>[]) {
+  debug("Collating Used Composables & Macros");
+  return results
+    .filter((r) => isComposableType(r) || isMacroType(r))
+    .map((el) => el.outputVariables);
+}

--- a/client/src/transformer/transforms/__tests__/mergeComposables.test.ts
+++ b/client/src/transformer/transforms/__tests__/mergeComposables.test.ts
@@ -1,4 +1,4 @@
-import { convertAst } from "@/convert";
+import { convertDefaultClassComponent } from "@/convert";
 import { getSingleFileProgram } from "@/parser";
 import { describe, expect, it } from "vitest";
 
@@ -29,7 +29,7 @@ describe("mergeComposables test", () => {
         }
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";

--- a/client/src/transformer/transforms/__tests__/mergeMacros.test.ts
+++ b/client/src/transformer/transforms/__tests__/mergeMacros.test.ts
@@ -1,4 +1,4 @@
-import { convertAst } from "@/convert";
+import { convertDefaultClassComponent } from "@/convert";
 import { getSingleFileProgram } from "@/parser";
 import { describe, expect, it } from "vitest";
 
@@ -25,7 +25,7 @@ describe("mergeMacros test", () => {
 
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "const props = withDefaults(defineProps<{

--- a/client/src/transformer/transforms/__tests__/processPropertyAccessAndSort.test.ts
+++ b/client/src/transformer/transforms/__tests__/processPropertyAccessAndSort.test.ts
@@ -1,4 +1,4 @@
-import { convertAst } from "@/convert";
+import { convertDefaultClassComponent } from "@/convert";
 import { getSingleFileProgram } from "@/parser";
 import { describe, expect, it } from "vitest";
 
@@ -22,7 +22,7 @@ describe("processPropertyAccessAndSort test", () => {
         foo: string = 'foo';
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { ref } from \\"vue\\";

--- a/client/src/transformer/transforms/__tests__/transformVccToComposable.test.ts
+++ b/client/src/transformer/transforms/__tests__/transformVccToComposable.test.ts
@@ -28,6 +28,10 @@ describe("processPropertyAccessAndSort test", () => {
           this.$store.dispatch('eos');
         }
 
+        get laboriosam() {
+          return this.$store.getters;
+        }
+
         @Prop() b: number;
         foo: string = 'foo';
       }
@@ -37,6 +41,7 @@ describe("processPropertyAccessAndSort test", () => {
     expect(result).toMatchInlineSnapshot(`
       "import { Component, Vue, Prop, Emit, Watch } from \\"vue-property-decorator\\";
       import Foo from \\"./Foo\\";
+      import { ref, computed } from \\"vue\\";
       @Component()
       export class Foo extends Vue {
           @Watch('bar')
@@ -52,6 +57,9 @@ describe("processPropertyAccessAndSort test", () => {
               }
               this.$store.dispatch('eos');
           }
+          get laboriosam() {
+              return this.$store.getters;
+          }
           @Prop()
           b: number;
           foo: string = 'foo';
@@ -59,6 +67,9 @@ describe("processPropertyAccessAndSort test", () => {
 
       export function useFoo(router, store, emit, props) {
           const foo = ref<string>(\\"foo\\");
+          const laboriosam = computed(() => {
+              return store.getters;
+          });
           const bar = const () => {
               if (props.b > 0) {
                   emit('foo', foo.value);
@@ -72,7 +83,7 @@ describe("processPropertyAccessAndSort test", () => {
           };
           watch(bar, handleBarChange);
           
-          return { foo, bar, handleBarChange };
+          return { foo, laboriosam, bar, handleBarChange };
       }
       "
     `);

--- a/client/src/transformer/transforms/__tests__/transformVccToComposable.test.ts
+++ b/client/src/transformer/transforms/__tests__/transformVccToComposable.test.ts
@@ -1,0 +1,130 @@
+import { convertMixinClassComponents } from "@/convert";
+import { getSingleFileProgram } from "@/parser";
+import { setIsMixin } from "@/registry";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("processPropertyAccessAndSort test", () => {
+  beforeEach(() => setIsMixin());
+
+  it("should process property access and sorts by dependencies", () => {
+    const { ast, program } = getSingleFileProgram(`
+      import { Component, Vue, Prop, Emit, Watch } from 'vue-property-decorator';
+      import Foo from './Foo';
+
+      @Component()
+      export class Foo extends Vue {
+        @Watch('bar')
+        handleBarChange(newVal: Foo) {
+          this.foo = \`\${newVal.toString()}\`;
+          this.bar();
+          this.$router.push({ name: 'eveniet' });
+        });
+
+        const bar() {
+          if (this.b > 0) {
+            this.$emit('foo', this.foo);
+          }
+
+          this.$store.dispatch('eos');
+        }
+
+        @Prop() b: number;
+        foo: string = 'foo';
+      }
+    `);
+    const result = convertMixinClassComponents(ast, program);
+
+    expect(result).toMatchInlineSnapshot(`
+      "import { Component, Vue, Prop, Emit, Watch } from \\"vue-property-decorator\\";
+      import Foo from \\"./Foo\\";
+      @Component()
+      export class Foo extends Vue {
+          @Watch('bar')
+          handleBarChange(newVal: Foo) {
+              this.foo = \`\${newVal.toString()}\`;
+              this.bar();
+              this.$router.push({ name: 'eveniet' });
+          }
+          ;
+          const bar() {
+              if (this.b > 0) {
+                  this.$emit('foo', this.foo);
+              }
+              this.$store.dispatch('eos');
+          }
+          @Prop()
+          b: number;
+          foo: string = 'foo';
+      }
+
+      export function useFoo(router, store, emit, props) {
+          const foo = ref<string>(\\"foo\\");
+          const bar = const () => {
+              if (props.b > 0) {
+                  emit('foo', foo.value);
+              }
+              store.dispatch('eos');
+          };
+          const handleBarChange = (newVal: Foo) => {
+              foo.value = \`\${newVal.toString()}\`;
+              bar();
+              router.push({ name: 'eveniet' });
+          };
+          watch(bar, handleBarChange);
+          
+          return { foo, bar, handleBarChange };
+      }
+      "
+    `);
+  });
+
+  it("should convert multiple mixins found in a single file", () => {
+    const { ast, program } = getSingleFileProgram(`
+      import { Component, Vue, Prop, Emit, Watch } from 'vue-property-decorator';
+      import Foo from './Foo';
+
+      @Component()
+      export class FooMixin extends Vue {
+        toggle() {
+        }
+      }
+
+      @Component()
+      export class BarMixin extends Vue {
+        open() {
+        }
+      }
+    `);
+    const result = convertMixinClassComponents(ast, program);
+
+    expect(result).toMatchInlineSnapshot(`
+      "import { Component, Vue, Prop, Emit, Watch } from \\"vue-property-decorator\\";
+      import Foo from \\"./Foo\\";
+      @Component()
+      export class FooMixin extends Vue {
+          toggle() {
+          }
+      }
+      @Component()
+      export class BarMixin extends Vue {
+          open() {
+          }
+      }
+
+      export function useFoo() {
+          const toggle = () => {
+          };
+          
+          return { toggle };
+      }
+
+      export function useBar() {
+          const open = () => {
+          };
+          
+          return { open };
+      }
+      "
+    `);
+  });
+});

--- a/client/src/transformer/transforms/processPropertyAccessAndSort.ts
+++ b/client/src/transformer/transforms/processPropertyAccessAndSort.ts
@@ -2,16 +2,20 @@ import { addTodoComment } from "@/helpers/comments.js";
 import { createIdentifier, createPropertyAccess } from "@/helpers/tsHelpers.js";
 import { isString } from "@/helpers/utils.js";
 import { VxPostProcessor, VxReferenceKind, VxResultToImport, VxTransformResult } from "@/types.js";
+import getDebug from "debug";
 import { cloneNode } from "ts-clone-node";
 import ts from "typescript";
 import { instancePropertyKeyMap } from "./utils/instancePropertyAccess.js";
+
+const debug = getDebug("vuedc:transformer:processPropertyAccessAndSort");
 
 type TransformerResult = {
   readonly astResult: Exclude<VxTransformResult<ts.Node>, VxResultToImport>;
   readonly dependsOn: string[];
 };
-export const processPropertyAccessAndSort: VxPostProcessor = (astResults, program) => {
-  const variableHandlers = getVariableHandlers(astResults, program);
+export const processPropertyAccessAndSort: VxPostProcessor = (astResults) => {
+  debug("Transforming property access expressions in bodies of methods");
+  const variableHandlers = getVariableHandlers(astResults);
 
   const transformerResults = astResults
     .map((astResult) => {
@@ -33,7 +37,7 @@ export const processPropertyAccessAndSort: VxPostProcessor = (astResults, progra
 };
 
 type VariableHandlers = ReturnType<typeof getVariableHandlers>;
-function getVariableHandlers(astResults: VxTransformResult<ts.Node>[], program: ts.Program) {
+function getVariableHandlers(astResults: VxTransformResult<ts.Node>[]) {
   const getReferences = (ref: VxReferenceKind) => {
     return astResults
       .filter((node) => node.reference === ref)

--- a/client/src/transformer/transforms/transformVccToComposable.ts
+++ b/client/src/transformer/transforms/transformVccToComposable.ts
@@ -1,16 +1,24 @@
 import { createIdentifier, newLineNode } from "@/helpers/tsHelpers";
 import { isMixin } from "@/registry";
-import { VxPostProcessor, VxReferenceKind, VxResultKind } from "@/types";
+import {
+  VxImportModule,
+  VxPostProcessor,
+  VxReferenceKind,
+  VxResultKind,
+  VxTransformResult,
+} from "@/types";
 import getDebug from "debug";
 import ts from "typescript";
 import { getBody, getUsedDefinables } from "../resultsProcessor";
+import { instanceDependencies, instancePropertyKeyLookup } from "./utils/instancePropertyAccess";
 
 const debug = getDebug("vuedc:transformer:transformMixin");
 const u = undefined;
 
 /**
  * When transforming a mixin, we need to transform the results into a composable
- * function
+ * function.
+ *
  * @param bodyResults collection of statements to insert into body of function
  * @param program
  * @returns
@@ -25,21 +33,13 @@ export const transformVccToComposable: VxPostProcessor = (bodyResults, _program,
   const id = createIdentifier(name);
   const body = getBody(bodyResults);
   const usedDefinables = getUsedDefinables(bodyResults);
-  const unwantedResultValues = usedDefinables.flat();
-  const returnValues = bodyResults.reduce((acc, result) => {
-    const { outputVariables } = result;
 
-    const props = outputVariables
-      .filter((v) => !unwantedResultValues.includes(v))
-      .map((v) => ts.factory.createShorthandPropertyAssignment(v));
-    acc.push(...props);
-    return acc;
-  }, [] as ts.ShorthandPropertyAssignment[]);
+  const { returnProps, imports } = getReturnPropsAndImports(bodyResults, usedDefinables);
 
   const paramVars = [...new Set(usedDefinables.flatMap((d) => d[0]))];
   const params = paramVars.map((d) => ts.factory.createParameterDeclaration(u, u, d, u));
 
-  const returnObject = ts.factory.createObjectLiteralExpression(returnValues, false);
+  const returnObject = ts.factory.createObjectLiteralExpression(returnProps, false);
   const returnStatement = ts.factory.createReturnStatement(returnObject);
 
   body.push(newLineNode(), returnStatement);
@@ -49,7 +49,7 @@ export const transformVccToComposable: VxPostProcessor = (bodyResults, _program,
   const composableFn = ts.factory.createFunctionDeclaration(mods, u, id, u, params, u, block);
   return [
     {
-      imports: [],
+      imports,
       kind: VxResultKind.COMPOSITION,
       nodes: [newLineNode(), composableFn],
       outputVariables: [],
@@ -58,3 +58,71 @@ export const transformVccToComposable: VxPostProcessor = (bodyResults, _program,
     },
   ];
 };
+
+function getImportClauses(i: VxImportModule) {
+  const clauses = i.named ?? [];
+  if (i.default) clauses.push(i.default);
+  return clauses;
+}
+
+type ReturnPropsAndImports = {
+  returnProps: ts.ShorthandPropertyAssignment[];
+  imports: VxImportModule[];
+};
+
+/**
+ * Returns the properties to export from the composable and a filtered list of
+ * imports needed to be added to the file
+ *
+ * @param bodyResults
+ * @param usedDefinables
+ * @returns
+ */
+function getReturnPropsAndImports(
+  bodyResults: VxTransformResult<ts.Node>[],
+  usedDefinables: string[][],
+) {
+  const unwantedResultValues = usedDefinables.flat();
+  const unwantedImports = getUnwantedImports(unwantedResultValues);
+
+  const propsAndImports = bodyResults.reduce(
+    (acc, result) => {
+      const { outputVariables, imports } = result;
+
+      const props = outputVariables
+        .filter((v) => !unwantedResultValues.includes(v))
+        .map((v) => ts.factory.createShorthandPropertyAssignment(v));
+
+      const importClauses = imports.filter((i) => {
+        const clauses = getImportClauses(i);
+        return !clauses.some((v) => unwantedImports.includes(v));
+      });
+
+      acc.returnProps.push(...props);
+      acc.imports.push(...importClauses);
+      return acc;
+    },
+    { returnProps: [], imports: [] } as ReturnPropsAndImports,
+  );
+
+  return propsAndImports;
+}
+
+/**
+ * We don't want to include imports for parameters expected to be passed to the
+ * composable function from the component
+ * @param unwantedResultValues
+ * @returns
+ */
+function getUnwantedImports(unwantedResultValues: string[]) {
+  return unwantedResultValues
+    .flatMap((v) => {
+      const key = instancePropertyKeyLookup.get(v);
+      if (!key) return;
+      const mods = instanceDependencies.get(key)?.();
+      if (!mods) return;
+      const clauses = mods.imports.flatMap((i) => getImportClauses(i));
+      return clauses;
+    })
+    .filter((v): v is string => !!v);
+}

--- a/client/src/transformer/transforms/transformVccToComposable.ts
+++ b/client/src/transformer/transforms/transformVccToComposable.ts
@@ -1,0 +1,60 @@
+import { createIdentifier, newLineNode } from "@/helpers/tsHelpers";
+import { isMixin } from "@/registry";
+import { VxPostProcessor, VxReferenceKind, VxResultKind } from "@/types";
+import getDebug from "debug";
+import ts from "typescript";
+import { getBody, getUsedDefinables } from "../resultsProcessor";
+
+const debug = getDebug("vuedc:transformer:transformMixin");
+const u = undefined;
+
+/**
+ * When transforming a mixin, we need to transform the results into a composable
+ * function
+ * @param bodyResults collection of statements to insert into body of function
+ * @param program
+ * @returns
+ */
+export const transformVccToComposable: VxPostProcessor = (bodyResults, _program, classNode) => {
+  if (!isMixin()) return bodyResults;
+
+  let name = classNode.name?.text ?? "AnonymousMixin";
+  debug(`Transforming ${name} into composable function.`);
+  name = `use${name[0].toUpperCase()}${name.slice(1)}`;
+  name = name.replace(/Mixin$/, "");
+  const id = createIdentifier(name);
+  const body = getBody(bodyResults);
+  const usedDefinables = getUsedDefinables(bodyResults);
+  const unwantedResultValues = usedDefinables.flat();
+  const returnValues = bodyResults.reduce((acc, result) => {
+    const { outputVariables } = result;
+
+    const props = outputVariables
+      .filter((v) => !unwantedResultValues.includes(v))
+      .map((v) => ts.factory.createShorthandPropertyAssignment(v));
+    acc.push(...props);
+    return acc;
+  }, [] as ts.ShorthandPropertyAssignment[]);
+
+  const paramVars = [...new Set(usedDefinables.flatMap((d) => d[0]))];
+  const params = paramVars.map((d) => ts.factory.createParameterDeclaration(u, u, d, u));
+
+  const returnObject = ts.factory.createObjectLiteralExpression(returnValues, false);
+  const returnStatement = ts.factory.createReturnStatement(returnObject);
+
+  body.push(newLineNode(), returnStatement);
+  const block = ts.factory.createBlock(body, true);
+
+  const mods = [ts.factory.createToken(ts.SyntaxKind.ExportKeyword)];
+  const composableFn = ts.factory.createFunctionDeclaration(mods, u, id, u, params, u, block);
+  return [
+    {
+      imports: [],
+      kind: VxResultKind.COMPOSITION,
+      nodes: [newLineNode(), composableFn],
+      outputVariables: [],
+      reference: VxReferenceKind.NONE,
+      tag: "ComposableFunction",
+    },
+  ];
+};

--- a/client/src/transformer/transforms/utils/instancePropertyAccess.ts
+++ b/client/src/transformer/transforms/utils/instancePropertyAccess.ts
@@ -16,7 +16,7 @@ import ts from "typescript";
  * are just imports from the main vue package now.
  */
 
-export const instancePropertyKeyMap = new Map<string, string | ts.PropertyAccessExpression>([
+const keyMap = [
   ["$attrs", "attrs"],
   ["$emit", "emit"],
   ["$nextTick", "nextTick"],
@@ -28,7 +28,11 @@ export const instancePropertyKeyMap = new Map<string, string | ts.PropertyAccess
   ["$slots", "slots"],
   ["$store", "store"],
   ["$watch", "watch"],
-]);
+] as const;
+const keyMapLookup = keyMap.map((k) => [k[1], k[0]] as const);
+
+export const instancePropertyKeyMap = new Map<string, string | ts.PropertyAccessExpression>(keyMap);
+export const instancePropertyKeyLookup = new Map<string, string>(keyMapLookup);
 
 export const instanceDependencies = new Map([
   ["$attrs", () => getConversion(VxResultKind.COMPOSABLE, "attrs", "useAttrs", "vue")],

--- a/client/src/transformer/transforms/vue-class-component/__tests__/Computed.test.ts
+++ b/client/src/transformer/transforms/vue-class-component/__tests__/Computed.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import { mergeComputed, transformGetter, transformSetter } from "../Computed.js";
 
 describe("Computed", () => {
+  const classNode = ts.factory.createClassDeclaration(undefined, "foo", undefined, undefined, []);
   it("should transform getter", () => {
     const { ast, program } = getSingleFileProgram("class foo { get a() { return 1 } }");
     const property = (ast.statements[0] as ts.ClassDeclaration)
@@ -57,7 +58,7 @@ describe("Computed", () => {
       expect(output.shouldContinue).toBe(false);
       const result = output.result;
       if (Array.isArray(result)) throw new Error("Expected result to be a single node");
-      const merged = mergeComputed([result], program);
+      const merged = mergeComputed([result], program, classNode);
       shouldBeTruthy(merged);
       expect(merged[0].tag).toBe("Computed");
       expect(merged[0].reference).toBe(VxReferenceKind.VARIABLE_VALUE);
@@ -84,7 +85,7 @@ describe("Computed", () => {
       const output = [outputGetter.result, outputSetter.result].filter(
         (o): o is VxTransformResult<ts.Node> => !!o,
       );
-      const merged = mergeComputed(output, program);
+      const merged = mergeComputed(output, program, classNode);
       expect(merged.length).toBe(1);
       expect(merged[0].tag).toBe("Computed");
       expect(merged[0].reference).toBe(VxReferenceKind.VARIABLE_VALUE);
@@ -105,7 +106,7 @@ describe("Computed", () => {
       const outputSetter = transformSetter(setter, program);
       expect(outputSetter.result).toBeTruthy();
       const output = [outputSetter.result].filter((o): o is VxTransformResult<ts.Node> => !!o);
-      const merged = mergeComputed(output, program);
+      const merged = mergeComputed(output, program, classNode);
       expect(merged.length).toBe(1);
       expect(merged[0].tag).toBe("Computed");
       expect(merged[0].reference).toBe(VxReferenceKind.VARIABLE_VALUE);

--- a/client/src/transformer/transforms/vue-class-component/__tests__/TemplaterRef.test.ts
+++ b/client/src/transformer/transforms/vue-class-component/__tests__/TemplaterRef.test.ts
@@ -1,4 +1,4 @@
-import { convertAst } from "@/convert.js";
+import { convertDefaultClassComponent } from "@/convert.js";
 import { getSingleFileProgram } from "@/parser.js";
 import { describe, expect, it } from "vitest";
 
@@ -17,7 +17,7 @@ describe("TemplateRef", () => {
 
 
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { ref } from \\"vue\\";

--- a/client/src/transformer/transforms/vue-class-component/decorator-options/__tests__/Emits.test.ts
+++ b/client/src/transformer/transforms/vue-class-component/decorator-options/__tests__/Emits.test.ts
@@ -1,4 +1,4 @@
-import { convertAst } from "@/convert.js";
+import { convertDefaultClassComponent } from "@/convert.js";
 import { getSingleFileProgram } from "@/parser.js";
 import { describe, expect, it } from "vitest";
 
@@ -9,7 +9,7 @@ describe("Emits", () => {
       @Component({ emits: ['a', 'b', 'c'] })
       export default class Foo { }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "const emit = defineEmits<{
@@ -39,7 +39,7 @@ describe("Emits", () => {
         }
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "const emit = defineEmits<{
@@ -72,7 +72,7 @@ describe("Emits", () => {
         }
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "const emit = defineEmits<{
@@ -101,7 +101,7 @@ describe("Emits", () => {
         }
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "const emit = defineEmits<{
@@ -126,7 +126,7 @@ describe("Emits", () => {
       @Component({ emits: 'a' })
       export default class Foo { }
     `);
-    expect(() => convertAst(ast, program)).toThrowError(
+    expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
       `[vue-class-component] emits option should be string[]`,
     );
   });

--- a/client/src/transformer/transforms/vue-class-component/decorator-options/__tests__/Expose.test.ts
+++ b/client/src/transformer/transforms/vue-class-component/decorator-options/__tests__/Expose.test.ts
@@ -1,4 +1,4 @@
-import { convertAst } from "@/convert.js";
+import { convertDefaultClassComponent } from "@/convert.js";
 import { getSingleFileProgram } from "@/parser.js";
 import { describe, expect, it } from "vitest";
 
@@ -13,7 +13,7 @@ describe("Emits", () => {
         c: number = 1;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { ref } from \\"vue\\";
@@ -31,7 +31,7 @@ describe("Emits", () => {
       @Options({ expose: 'a' })
       export default class Foo { }
     `);
-    expect(() => convertAst(ast, program)).toThrowError(
+    expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
       `[vue-class-component] expose option should be string[]`,
     );
   });
@@ -42,7 +42,7 @@ describe("Emits", () => {
       @Options({ expose: [a] })
       export default class Foo { }
     `);
-    expect(() => convertAst(ast, program)).toThrowError(
+    expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
       `[vue-class-component] expose option should be string[]`,
     );
   });

--- a/client/src/transformer/transforms/vue-class-component/decorator-options/__tests__/Props.test.ts
+++ b/client/src/transformer/transforms/vue-class-component/decorator-options/__tests__/Props.test.ts
@@ -1,6 +1,6 @@
-import { convertAst } from "@/convert";
+import { convertDefaultClassComponent } from "@/convert";
 import { getSingleFileProgram } from "@/parser";
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 describe("@Component props definition", () => {
   it("should transform a array of strings", () => {
@@ -9,7 +9,7 @@ describe("@Component props definition", () => {
       @Options({ props: ['a', 'b', 'c'] })
       export default class Foo {}
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "const props = defineProps<{
@@ -27,7 +27,7 @@ describe("@Component props definition", () => {
       @Options({ props: { a: String, b: Boolean, c: Number } })
       export default class Foo {}
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "const props = defineProps<{
@@ -49,7 +49,7 @@ describe("@Component props definition", () => {
       } })
       export default class Foo {}
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "const props = withDefaults(defineProps<{
@@ -74,7 +74,7 @@ describe("@Component props definition", () => {
       } })
       export default class Foo {}
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "const props = withDefaults(defineProps<{
@@ -94,7 +94,7 @@ describe("@Component props definition", () => {
       @Options({ props: 'a' })
       export default class Foo {}
     `);
-    expect(() => convertAst(ast, program)).toThrowError(
+    expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
       "[vue-class-component] props option expecting `string[] | Object`",
     );
   });

--- a/client/src/transformer/transforms/vue-class-component/decorator-options/__tests__/Watches.test.ts
+++ b/client/src/transformer/transforms/vue-class-component/decorator-options/__tests__/Watches.test.ts
@@ -1,4 +1,4 @@
-import { convertAst } from "@/convert";
+import { convertDefaultClassComponent } from "@/convert";
 import { getSingleFileProgram } from "@/parser";
 import { describe, expect, it } from "vitest";
 
@@ -9,7 +9,7 @@ describe("@Component watches definition", () => {
       @Options({ watch: { a: function () {} } })
       export default class Foo {}
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { watch } from \\"vue\\";
@@ -26,7 +26,7 @@ describe("@Component watches definition", () => {
         a: { b: { c: string } } = { b: { c: 'c' } };
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { reactive, watch } from \\"vue\\";
@@ -49,7 +49,7 @@ describe("@Component watches definition", () => {
         getA() {}
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { reactive, watch } from \\"vue\\";
@@ -68,7 +68,7 @@ describe("@Component watches definition", () => {
       } })
       export default class Foo {}
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { watch } from \\"vue\\";
@@ -92,7 +92,7 @@ describe("@Component watches definition", () => {
         getA() {}
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { reactive, watch } from \\"vue\\";
@@ -111,7 +111,7 @@ describe("@Component watches definition", () => {
       @Options({ watch: 'a' })
       export default class Foo {}
     `);
-    expect(() => convertAst(ast, program)).toThrowError(
+    expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
       `[vue-class-component] watch option should be an object`,
     );
   });

--- a/client/src/transformer/transforms/vue-property-decorator/__tests__/Emit.test.ts
+++ b/client/src/transformer/transforms/vue-property-decorator/__tests__/Emit.test.ts
@@ -1,6 +1,6 @@
-import { convertAst } from "@/convert";
+import { convertDefaultClassComponent } from "@/convert";
 import { getSingleFileProgram } from "@/parser";
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 describe("Emit decorator", () => {
   it("should transform emit decorator using method name as event name", () => {
@@ -13,7 +13,7 @@ describe("Emit decorator", () => {
         }
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "const emit = defineEmits<{
@@ -37,7 +37,7 @@ describe("Emit decorator", () => {
         }
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "const emit = defineEmits<{
@@ -63,7 +63,7 @@ describe("Emit decorator", () => {
         }
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "const emit = defineEmits<{
@@ -88,7 +88,7 @@ describe("Emit decorator", () => {
         }
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "const emit = defineEmits<{
@@ -118,7 +118,7 @@ describe("Emit decorator", () => {
         }
       }
     `);
-    expect(() => convertAst(ast, program)).toThrowError(
+    expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
       `[vue-property-decorator] Multiple @Emit decorators found on foo`,
     );
   });
@@ -133,7 +133,7 @@ describe("Emit decorator", () => {
         }
       }
     `);
-    expect(() => convertAst(ast, program)).toThrowError(
+    expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
       `[vue-property-decorator] Expected @Emit to be a call expression`,
     );
   });

--- a/client/src/transformer/transforms/vue-property-decorator/__tests__/Inject.test.ts
+++ b/client/src/transformer/transforms/vue-property-decorator/__tests__/Inject.test.ts
@@ -1,4 +1,4 @@
-import { convertAst } from "@/convert";
+import { convertDefaultClassComponent } from "@/convert";
 import { getSingleFileProgram } from "@/parser";
 import { describe, expect, it } from "vitest";
 
@@ -12,7 +12,7 @@ describe("Inject decorator", () => {
         foo: string;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { inject } from \\"vue\\";
@@ -30,7 +30,7 @@ describe("Inject decorator", () => {
         bar: string;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { inject } from \\"vue\\";
@@ -48,7 +48,7 @@ describe("Inject decorator", () => {
         bar: string;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { inject } from \\"vue\\";
@@ -66,7 +66,7 @@ describe("Inject decorator", () => {
         bar: { bar: string };
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { inject } from \\"vue\\";
@@ -86,7 +86,7 @@ describe("Inject decorator", () => {
         bar: number[];
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { inject } from \\"vue\\";
@@ -105,7 +105,7 @@ describe("Inject decorator", () => {
         bar: string;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { inject } from \\"vue\\";
@@ -125,7 +125,7 @@ describe("Inject decorator", () => {
         foo: string;
       }
     `);
-    expect(() => convertAst(ast, program)).toThrowError(
+    expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
       `[vue-property-decorator] Duplicate @Inject decorators for foo`,
     );
   });

--- a/client/src/transformer/transforms/vue-property-decorator/__tests__/Prop.test.ts
+++ b/client/src/transformer/transforms/vue-property-decorator/__tests__/Prop.test.ts
@@ -1,4 +1,4 @@
-import { convertAst } from "@/convert";
+import { convertDefaultClassComponent } from "@/convert";
 import { getSingleFileProgram } from "@/parser";
 import { describe, expect, it } from "vitest";
 
@@ -12,7 +12,7 @@ describe("Prop decorator", () => {
         foo: string;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "const props = defineProps<{
@@ -31,7 +31,7 @@ describe("Prop decorator", () => {
         foo;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "const props = defineProps<{
@@ -50,7 +50,7 @@ describe("Prop decorator", () => {
         foo;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "const props = withDefaults(defineProps<{
@@ -73,7 +73,7 @@ describe("Prop decorator", () => {
         @Prop bar: Bar;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import Bar from \\"./Bar\\";
@@ -96,7 +96,7 @@ describe("Prop decorator", () => {
         foo: string;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "const props = defineProps<{
@@ -116,7 +116,7 @@ describe("Prop decorator", () => {
         foo: string;
       }
     `);
-    expect(() => convertAst(ast, program)).toThrowError(
+    expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
       `[vue-property-decorator] Duplicate @Prop decorators for foo`,
     );
   });

--- a/client/src/transformer/transforms/vue-property-decorator/__tests__/Provide.test.ts
+++ b/client/src/transformer/transforms/vue-property-decorator/__tests__/Provide.test.ts
@@ -1,6 +1,6 @@
-import { convertAst } from "@/convert";
+import { convertDefaultClassComponent } from "@/convert";
 import { getSingleFileProgram } from "@/parser";
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 describe("Provide decorator", () => {
   it("should transform provide decorator using local name as provide name", () => {
@@ -12,7 +12,7 @@ describe("Provide decorator", () => {
         foo = 'bar';
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { ref, provide } from \\"vue\\";
@@ -31,7 +31,7 @@ describe("Provide decorator", () => {
         bar = 'baz';
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { ref, provide } from \\"vue\\";
@@ -50,7 +50,7 @@ describe("Provide decorator", () => {
         bar = 'baz';
       }
     `);
-    expect(() => convertAst(ast, program)).toThrowError(
+    expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
       `[vue-class-component] Expected @Provide to be a string literal`,
     );
   });
@@ -65,7 +65,7 @@ describe("Provide decorator", () => {
         baz = 'baz';
       }
     `);
-    expect(() => convertAst(ast, program)).toThrowError(
+    expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
       `[vue-class-component] Duplicate @Provide decorators for baz`,
     );
   });

--- a/client/src/transformer/transforms/vue-property-decorator/__tests__/Ref.test.ts
+++ b/client/src/transformer/transforms/vue-property-decorator/__tests__/Ref.test.ts
@@ -1,4 +1,4 @@
-import { convertAst } from "@/convert";
+import { convertDefaultClassComponent } from "@/convert";
 import { getSingleFileProgram } from "@/parser";
 import { describe, expect, it } from "vitest";
 
@@ -12,7 +12,7 @@ describe("Ref decorator", () => {
         foo: string;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { ref } from \\"vue\\";
@@ -30,7 +30,7 @@ describe("Ref decorator", () => {
         bar: string;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { ref } from \\"vue\\";
@@ -48,7 +48,7 @@ describe("Ref decorator", () => {
         bar: string;
       }
     `);
-    expect(() => convertAst(ast, program)).toThrowError(
+    expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
       `[vue-property-decorator] Expected @Ref to be a string literal`,
     );
   });
@@ -63,7 +63,7 @@ describe("Ref decorator", () => {
         bar: string;
       }
     `);
-    expect(() => convertAst(ast, program)).toThrowError(
+    expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
       `[vue-property-decorator] Duplicate @Ref decorators for bar`,
     );
   });

--- a/client/src/transformer/transforms/vue-property-decorator/__tests__/Watch.test.ts
+++ b/client/src/transformer/transforms/vue-property-decorator/__tests__/Watch.test.ts
@@ -1,4 +1,4 @@
-import { convertAst } from "@/convert";
+import { convertDefaultClassComponent } from "@/convert";
 import { getSingleFileProgram } from "@/parser";
 import { describe, expect, it } from "vitest";
 
@@ -14,7 +14,7 @@ describe("Watch decorator", () => {
         bar() {}
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { ref } from \\"vue\\";
@@ -38,7 +38,7 @@ describe("Watch decorator", () => {
         baz() {}
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { ref } from \\"vue\\";
@@ -62,7 +62,7 @@ describe("Watch decorator", () => {
         bar() {}
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { ref } from \\"vue\\";
@@ -84,7 +84,7 @@ describe("Watch decorator", () => {
         bar() {}
       }
     `);
-    expect(() => convertAst(ast, program)).toThrowError(
+    expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
       `[vue-property-decorator] Expected @Watch for bar to be a call expression`,
     );
   });
@@ -100,7 +100,7 @@ describe("Watch decorator", () => {
         bar() {}
       }
     `);
-    expect(() => convertAst(ast, program)).toThrowError(
+    expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
       `[vue-property-decorator] Expected @Watch for bar to be called with a string as first argument`,
     );
   });

--- a/client/src/transformer/transforms/vue-property-decorator/__tests__/mixins.test.ts
+++ b/client/src/transformer/transforms/vue-property-decorator/__tests__/mixins.test.ts
@@ -1,4 +1,4 @@
-import { convertAst } from "@/convert";
+import { convertDefaultClassComponent } from "@/convert";
 import { readVueFile } from "@/file";
 import { getSingleFileProgram } from "@/parser";
 import { setImportNameOverride } from "@/registry";
@@ -16,7 +16,7 @@ describe("mixins test", () => {
       resolve(__dirname, "./fixtures"),
       resolve(__dirname, "./fixtures/tsconfig.json"),
     );
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import MyOther, { useMyOther } from \\"./MyOther\\";

--- a/client/src/transformer/transforms/vue-property-decorator/mixins.ts
+++ b/client/src/transformer/transforms/vue-property-decorator/mixins.ts
@@ -26,7 +26,7 @@ export const transformMixins: VxTransform<ts.HeritageClause> = (clause, program)
   const typeIdent = typeExpr.expression;
   if (!ts.isIdentifier(typeIdent)) return { shouldContinue: true };
 
-  let clauseName = getImportNameOverride(CLAUSE) ?? CLAUSE;
+  let clauseName = getImportNameOverride(CLAUSE);
   debug(`Mixin var: ${clauseName}`);
   if (typeIdent.text !== clauseName) return { shouldContinue: true };
 

--- a/client/src/transformer/transforms/vuex-class/__tests__/Action.test.ts
+++ b/client/src/transformer/transforms/vuex-class/__tests__/Action.test.ts
@@ -1,4 +1,4 @@
-import { convertAst } from "@/convert";
+import { convertDefaultClassComponent } from "@/convert";
 import { getSingleFileProgram } from "@/parser";
 import { describe, expect, it } from "vitest";
 
@@ -17,7 +17,7 @@ describe("Action decorator", () => {
         @ns2.Action qux: () => void;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
@@ -44,7 +44,7 @@ describe("Action decorator", () => {
         @ns2.Action('bar') qux: () => void;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
@@ -71,7 +71,7 @@ describe("Action decorator", () => {
         @ns2.Action('baz/foo') qux: () => void;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
@@ -98,7 +98,7 @@ describe("Action decorator", () => {
         @ns2.Action('baz/foo') qux: () => string;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
@@ -130,7 +130,7 @@ describe("Action decorator", () => {
         @ns2.Action(keys.actions.foo) inventore: (a: string) => void;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
@@ -162,7 +162,7 @@ describe("Action decorator", () => {
         @ns2.Action qux;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
@@ -187,7 +187,7 @@ describe("Action decorator", () => {
         @${prefix}Action @${prefix}Action foo: () => void;
       }
     `);
-    expect(() => convertAst(ast, program)).toThrowError(
+    expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
       "[vuex-class] Duplicate @Action decorators for foo",
     );
   });
@@ -203,7 +203,7 @@ describe("Action decorator", () => {
         @${prefix}Action foo: (a: string, b: string) => void;
       }
     `);
-      expect(() => convertAst(ast, program)).toThrowError(
+      expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
         "[vuex-class] foo dispatch signature has more than 1 parameter.",
       );
     },

--- a/client/src/transformer/transforms/vuex-class/__tests__/Getter.test.ts
+++ b/client/src/transformer/transforms/vuex-class/__tests__/Getter.test.ts
@@ -1,4 +1,4 @@
-import { convertAst } from "@/convert";
+import { convertDefaultClassComponent } from "@/convert";
 import { getSingleFileProgram } from "@/parser";
 import { describe, expect, it } from "vitest";
 
@@ -17,7 +17,7 @@ describe("Getter decorator", () => {
         @ns2.Getter qux: string;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
@@ -45,7 +45,7 @@ describe("Getter decorator", () => {
         @ns2.Getter('foo') qux: string;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
@@ -78,7 +78,7 @@ describe("Getter decorator", () => {
         @ns2.Getter(storeKeys.getters.foo) officiis: string;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
@@ -106,7 +106,7 @@ describe("Getter decorator", () => {
         @Getter('ns/foo') bar: string;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
@@ -127,7 +127,7 @@ describe("Getter decorator", () => {
         @Getter('ns/' + foo) bar: () => string;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
@@ -149,7 +149,7 @@ describe("Getter decorator", () => {
       }
     `);
 
-    expect(() => convertAst(ast, program)).toThrowError(
+    expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
       `[vuex-class] Unexpected decorator argument, expected String or Identifier got ArrowFunction`,
     );
   });

--- a/client/src/transformer/transforms/vuex-class/__tests__/Mutation.test.ts
+++ b/client/src/transformer/transforms/vuex-class/__tests__/Mutation.test.ts
@@ -1,4 +1,4 @@
-import { convertAst } from "@/convert";
+import { convertDefaultClassComponent } from "@/convert";
 import { getSingleFileProgram } from "@/parser";
 import { describe, expect, it } from "vitest";
 
@@ -17,7 +17,7 @@ describe("Mutation decorator", () => {
         @ns2.Mutation qux: () => void;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
@@ -44,7 +44,7 @@ describe("Mutation decorator", () => {
         @ns2.Mutation('bar') qux: () => void;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
@@ -71,7 +71,7 @@ describe("Mutation decorator", () => {
         @ns2.Mutation('baz/foo') qux: () => void;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
@@ -99,7 +99,7 @@ describe("Mutation decorator", () => {
         @ns2.Mutation('baz/foo') qux: () => string;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
@@ -132,7 +132,7 @@ describe("Mutation decorator", () => {
         @ns2.Mutation(keys.mutations.foo) impedit: (a: string) => void;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
@@ -164,7 +164,7 @@ describe("Mutation decorator", () => {
         @ns2.Mutation qux;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
@@ -189,7 +189,7 @@ describe("Mutation decorator", () => {
         @${prefix}Mutation @${prefix}Mutation foo: () => void;
       }
     `);
-    expect(() => convertAst(ast, program)).toThrowError(
+    expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
       "[vuex-class] Duplicate @Mutation decorators for foo",
     );
   });
@@ -208,7 +208,7 @@ describe("Mutation decorator", () => {
         @${prefix}Mutation foo: (a: string, b: string) => void;
       }
     `);
-      expect(() => convertAst(ast, program)).toThrowError(
+      expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
         "[vuex-class] foo commit signature has more than 1 parameter.",
       );
     },

--- a/client/src/transformer/transforms/vuex-class/__tests__/State.test.ts
+++ b/client/src/transformer/transforms/vuex-class/__tests__/State.test.ts
@@ -1,4 +1,4 @@
-import { convertAst } from "@/convert";
+import { convertDefaultClassComponent } from "@/convert";
 import { getSingleFileProgram } from "@/parser";
 import { describe, expect, it } from "vitest";
 
@@ -17,7 +17,7 @@ describe("State decorator", () => {
         @ns2.State qux: string;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
@@ -45,7 +45,7 @@ describe("State decorator", () => {
         @ns2.State('foo') qux: string;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
@@ -78,7 +78,7 @@ describe("State decorator", () => {
         @ns2.State(keys.state.foo) eius: string;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
@@ -106,7 +106,7 @@ describe("State decorator", () => {
         @State('ns/foo') bar: string;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
@@ -127,7 +127,7 @@ describe("State decorator", () => {
         @State('ns/' + foo) bar: () => string;
       }
     `);
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
 
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
@@ -154,7 +154,7 @@ describe("State decorator", () => {
       }
     `);
 
-    const result = convertAst(ast, program);
+    const result = convertDefaultClassComponent(ast, program);
     expect(result).toMatchInlineSnapshot(`
       "import { useStore } from \\"vuex\\";
       import { computed } from \\"vue\\";
@@ -176,7 +176,7 @@ describe("State decorator", () => {
         @State @State foo: string;
       }
     `);
-    expect(() => convertAst(ast, program)).toThrowError(
+    expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
       "[vuex-class] Duplicate @State decorators for foo",
     );
   });
@@ -191,7 +191,7 @@ describe("State decorator", () => {
         @ns.State @ns.State foo: string;
       }
     `);
-    expect(() => convertAst(ast, program)).toThrowError(
+    expect(() => convertDefaultClassComponent(ast, program)).toThrowError(
       "[vuex-class] Duplicate @State decorators for foo",
     );
   });

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -150,6 +150,7 @@ export type VxTransform<T extends ts.Node> = (
 export type VxPostProcessor = (
   astResults: VxTransformResult<ts.Node>[],
   program: ts.Program,
+  classNode: ts.ClassDeclaration,
 ) => VxTransformResult<ts.Node>[];
 
 export interface VxClassTransforms {


### PR DESCRIPTION
In the CLI when provided a `.ts` file Vuedc will attempt to create composable functions from any VCC Mixins found in the file.

The composable will be appended to the file rather than replacing the Mixin as it is possible the Mixin may be used by as of yet unconverted VCC components.