### PR TITLE
Strip most method modifiers

### DIFF
--- a/.changeset/gold-mayflies-give.md
+++ b/.changeset/gold-mayflies-give.md
@@ -1,0 +1,5 @@
+---
+"@heatsrc/vue-declassified": patch
+---
+
+Stip all method modifiers except async from method conversions

--- a/client/src/helpers/tsHelpers.ts
+++ b/client/src/helpers/tsHelpers.ts
@@ -79,7 +79,7 @@ export function createArrowFunction(
   multiline?: boolean,
 ) {
   const { body, parameters, type, typeParameters } = node;
-  const modifiers = ts.getModifiers(node);
+  const modifiers = ts.getModifiers(node)?.filter((m) => m.kind === ts.SyntaxKind.AsyncKeyword);
   const rocket = rocketToken();
   const fnBody = statements
     ? factory.createBlock(statements, multiline)

--- a/client/src/transformer/transforms/__tests__/processPropertyAccessAndSort.test.ts
+++ b/client/src/transformer/transforms/__tests__/processPropertyAccessAndSort.test.ts
@@ -35,7 +35,7 @@ describe("processPropertyAccessAndSort test", () => {
           \\"b\\": number;
       }>();
       const foo = ref<string>(\\"foo\\");
-      const bar = const () => {
+      const bar = () => {
           emit('foo', foo.value);
       };
       const handleBPropChange = (newVal: number) => {

--- a/client/src/transformer/transforms/__tests__/transformVccToComposable.test.ts
+++ b/client/src/transformer/transforms/__tests__/transformVccToComposable.test.ts
@@ -20,7 +20,7 @@ describe("processPropertyAccessAndSort test", () => {
           this.$router.push({ name: 'eveniet' });
         });
 
-        const bar() {
+        bar() {
           if (this.b > 0) {
             this.$emit('foo', this.foo);
           }
@@ -51,7 +51,7 @@ describe("processPropertyAccessAndSort test", () => {
               this.$router.push({ name: 'eveniet' });
           }
           ;
-          const bar() {
+          bar() {
               if (this.b > 0) {
                   this.$emit('foo', this.foo);
               }
@@ -70,7 +70,7 @@ describe("processPropertyAccessAndSort test", () => {
           const laboriosam = computed(() => {
               return store.getters;
           });
-          const bar = const () => {
+          const bar = () => {
               if (props.b > 0) {
                   emit('foo', foo.value);
               }

--- a/client/src/transformer/transforms/vue-class-component/__tests__/Method.test.ts
+++ b/client/src/transformer/transforms/vue-class-component/__tests__/Method.test.ts
@@ -1,52 +1,59 @@
+import { convertDefaultClassComponent } from "@/convert.js";
 import { getSingleFileProgram } from "@/parser.js";
-import { VxReferenceKind, VxResultKind } from "@/types.js";
-import { shouldBeTruthy } from "@test/customAssertions.js";
-import ts from "typescript";
 import { describe, expect, it } from "vitest";
-import { transformMethod } from "../Method.js";
 
 describe("Method", () => {
   it("should transform a method to function expression", () => {
-    const { ast, program } = getSingleFileProgram("class foo { a() { return 1 } }");
-    const method = (ast.statements[0] as ts.ClassDeclaration).members[0] as ts.MethodDeclaration;
-    const output = transformMethod(method, program);
+    const { ast, program } = getSingleFileProgram(`
+      import { Component } from 'vue-class-component';
+      @Component
+      export default class Foo {
+        a() { return 1 }
+      }
+    `);
+    const result = convertDefaultClassComponent(ast, program);
 
-    shouldBeTruthy(output);
-    shouldBeTruthy(output.result);
-    expect(output.shouldContinue).toBe(false);
-    const result = output.result;
-    if (Array.isArray(result)) throw new Error("Expected result to be a single node");
-    expect(result.tag).toBe("Method");
-    expect(result.reference).toBe(VxReferenceKind.VARIABLE);
-    expect(result.kind).toBe(VxResultKind.COMPOSITION);
-    expect(result.nodes.length).toBe(1);
-    expect(result.outputVariables).toEqual(["a"]);
-    // no additional comments added
-    expect((result.nodes[0] as any).emitNode).toBeUndefined();
+    expect(result).toMatchInlineSnapshot(`
+      "const a = () => { return 1; };
+      "
+    `);
   });
 
   it("should add a todo comment for unsupported decorators", () => {
     const { ast, program } = getSingleFileProgram(`
-      class foo {
+      import { Component } from 'vue-class-component';
+      @Component
+      export default class foo {
         @Bar
         a() { return 1 }
       }
     `);
 
-    const method = (ast.statements[0] as ts.ClassDeclaration).members[0] as ts.MethodDeclaration;
-    method.type?.getText();
-    const output = transformMethod(method, program);
+    const result = convertDefaultClassComponent(ast, program);
 
-    shouldBeTruthy(output);
-    shouldBeTruthy(output.result);
-    expect(output.shouldContinue).toBe(false);
-    const result = output.result;
-    if (Array.isArray(result)) throw new Error("Expected result to be a single node");
-    expect(result.tag).toBe("Method");
-    expect(result.reference).toBe(VxReferenceKind.VARIABLE);
-    expect(result.kind).toBe(VxResultKind.COMPOSITION);
-    expect(result.nodes.length).toBe(1);
-    expect(result.outputVariables).toEqual(["a"]);
-    expect((result.nodes[0] as any).emitNode.leadingComments[0].text).toContain("VUEDC_TODO");
+    expect(result).toMatchInlineSnapshot(`
+      "/* [VUEDC_TODO]: Encountered unsupported decorator(s): \\"@Bar\\"*/ const a = () => { return 1; };
+      "
+    `);
+  });
+
+  it("should strip access modifiers from methods", () => {
+    const { ast, program } = getSingleFileProgram(`
+      import { Component } from 'vue-class-component';
+      @Component
+      export default class Foo {
+        public a() { return 1 }
+        protected b() { return 2 }
+        private c() { return 3 }
+       }
+    `);
+    const result = convertDefaultClassComponent(ast, program);
+
+    expect(result).toMatchInlineSnapshot(`
+      "const a = () => { return 1; };
+      const b = () => { return 2; };
+      const c = () => { return 3; };
+      "
+    `);
   });
 });


### PR DESCRIPTION
We want to keep async if it's there but semanticall access modifiers on methods make no sense after conversion.